### PR TITLE
feat: make TLS opt-in for local use

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
+      - name: Install Node test dependencies
+        run: npm ci
       - name: Install checked tooling
         run: sudo apt-get update && sudo apt-get install --yes cmake ninja-build g++ clang ccache cppcheck clang-tidy shellcheck ripgrep
       - name: CMake, CTest, and coverage
@@ -39,6 +41,14 @@ jobs:
           cmake --preset core-coverage-gcc
           cmake --build --preset core-coverage-gcc
           ctest --preset core-coverage-gcc
+      - name: Real chat session
+        run: |
+          ./scripts/build-vendored-oatpp.sh
+          cmake --preset native-gcc \
+            -DCONSPIRE_DEPS_PREFIX="$GITHUB_WORKSPACE/build/deps" \
+            -DCONSPIRE_VERSION=e2e
+          cmake --build --preset native-gcc --target conspire-exe
+          npm run test:e2e
       - name: Browser gates
         run: npm run check:web && npm run coverage:browser
       - name: Static gates

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
           node-version: 22
       - name: Install Node test dependencies
         run: npm ci
+      - name: Install browser test runtime
+        run: npx playwright install --with-deps chromium
       - name: Install checked tooling
         run: sudo apt-get update && sudo apt-get install --yes cmake ninja-build g++ clang ccache cppcheck clang-tidy shellcheck ripgrep
       - name: CMake, CTest, and coverage
@@ -49,6 +51,7 @@ jobs:
             -DCONSPIRE_VERSION=e2e
           cmake --build --preset native-gcc --target conspire-exe
           npm run test:e2e
+          npm run test:e2e:browser
       - name: Browser gates
         run: npm run check:web && npm run coverage:browser
       - name: Static gates

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ coverage/
 dist/
 cert/
 node_modules/
+playwright-report/
+test-results/
 
 # Mac
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 coverage/
 dist/
 cert/
+node_modules/
 
 # Mac
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --chown=conspire:conspire front /app/front
 USER conspire:conspire
 VOLUME ["/run/conspire"]
 EXPOSE 8443
-ENTRYPOINT ["/app/conspire"]
+ENTRYPOINT ["/app/conspire", "--tls"]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ TLS is opt-in. Pass `--tls` together with certificate paths when it is needed:
   --tls-key cert/privkey.pem --tls-chain cert/fullchain.pem
 ```
 
+The real-process chat test starts this native binary on an isolated localhost
+port, connects three WebSocket clients, verifies broadcast and room history,
+and checks clean shutdown:
+
+```bash
+npm ci
+npm run test:e2e
+```
+
 Without the prefix, configure stops immediately with the exact prerequisite and
 does not fetch a dependency. Release CI creates it from `vendor/` with the
 same musl toolchain used for the release artifact.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ cmake --build --preset native-clang
 ctest --preset native-clang
 ```
 
+For a certificate-free local run, start the native build without `--tls` and
+open <http://localhost:8080>:
+
+```bash
+./build/native-gcc/server/conspire-exe
+```
+
+TLS is opt-in. Pass `--tls` together with certificate paths when it is needed:
+
+```bash
+./build/native-gcc/server/conspire-exe --tls --port 8443 \
+  --tls-key cert/privkey.pem --tls-chain cert/fullchain.pem
+```
+
 Without the prefix, configure stops immediately with the exact prerequisite and
 does not fetch a dependency. Release CI creates it from `vendor/` with the
 same musl toolchain used for the release artifact.

--- a/README.md
+++ b/README.md
@@ -71,13 +71,17 @@ TLS is opt-in. Pass `--tls` together with certificate paths when it is needed:
   --tls-key cert/privkey.pem --tls-chain cert/fullchain.pem
 ```
 
-The real-process chat test starts this native binary on an isolated localhost
-port, connects three WebSocket clients, verifies broadcast and room history,
-and checks clean shutdown:
+The real-process tests start this native binary on isolated localhost ports.
+The protocol test connects three WebSocket clients, verifies broadcast and room
+history, and checks clean shutdown. The Playwright test drives the served UI in
+three independent browser contexts and verifies the versioned title,
+participants, message delivery, and history without TLS:
 
 ```bash
 npm ci
+npx playwright install chromium
 npm run test:e2e
+npm run test:e2e:browser
 ```
 
 Without the prefix, configure stops immediately with the exact prerequisite and

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -101,7 +101,7 @@ Type=simple
 User=conspire
 Group=conspire
 WorkingDirectory=/opt/conspire
-ExecStart=/opt/conspire/conspire
+ExecStart=/opt/conspire/conspire --tls
 Environment=EXTERNAL_ADDRESS=your-domain.com
 Environment=EXTERNAL_PORT=8443
 Environment=TLS_FILE_PRIVATE_KEY=cert/privkey.pem
@@ -205,9 +205,13 @@ For infrastructure-as-code deployment, see [conspire-infra](https://github.com/s
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `EXTERNAL_ADDRESS` | localhost | Public hostname |
-| `EXTERNAL_PORT` | 8443 | WebSocket port |
-| `TLS_FILE_PRIVATE_KEY` | — | Path to private key |
-| `TLS_FILE_CERT_CHAIN` | — | Path to certificate chain |
+| `EXTERNAL_PORT` | 8080 (8443 with `--tls`) | HTTP/WebSocket port |
+| `TLS_FILE_PRIVATE_KEY` | — | Private key path, read only with `--tls` |
+| `TLS_FILE_CERT_CHAIN` | — | Certificate-chain path, read only with `--tls` |
+
+For a local certificate-free smoke test, run `./conspire` without TLS options
+and open <http://localhost:8080>. Use `./conspire --tls` for the certificate
+configuration described above.
 
 ## Troubleshooting
 

--- a/front/chat/chat.js
+++ b/front/chat/chat.js
@@ -20,7 +20,7 @@ let CODE_FILE_CHUNK_DATA = 8;
 
 let socket = new WebSocket(urlWebsocket);
 let protocolModule = import(urlRoom + "/protocol.js");
-let peedId = null;
+let peerId = null;
 let peerName = null;
 let peersMap = new Map();
 const chatState = createChatState();

--- a/front/chat/index.html
+++ b/front/chat/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-    <title>Conspire Chat</title>
+    <title>%%%CONSPIRE_TITLE%%%</title>
 
     <link rel="stylesheet" href="/room/%%%ROOM_ID%%%/chat.css">
 </head>

--- a/front/index.html
+++ b/front/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Denis "Jaromil" Roio - Inventor, Ph.D.</title>
+    <title>%%%CONSPIRE_TITLE%%%</title>
     <meta name="description" content="Web-based chat for radical exchange: ephemeral, anonymous, and synchronous." />
     <meta name="keywords" content="web-chat, anonymous, file-sharing, commons" />
     <meta charset="utf-8" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "conspire-quality-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "conspire-quality-tests",
+      "devDependencies": {
+        "ws": "8.21.3"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,71 @@
     "": {
       "name": "conspire-quality-tests",
       "devDependencies": {
+        "@playwright/test": "1.62.1",
         "ws": "8.21.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "scripts": {
     "test:browser": "node --test test/*.test.mjs",
     "test:e2e": "node --test test/e2e/*.test.mjs",
+    "test:e2e:browser": "playwright test",
     "coverage:browser": "node --experimental-test-coverage --test-coverage-lines=70 --test-coverage-branches=70 --test test/browser-protocol.test.mjs",
     "check:js": "node --check front/chat/chat.js && node --check front/chat/ui.js && node --check front/chat/state.js && node --check front/chat/format.js && node --check dashboard/app.js && node --check front/lobby.js",
     "check:web": "npm run check:js && npm run test:browser"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
     "ws": "8.21.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "type": "module",
   "scripts": {
     "test:browser": "node --test test/*.test.mjs",
+    "test:e2e": "node --test test/e2e/*.test.mjs",
     "coverage:browser": "node --experimental-test-coverage --test-coverage-lines=70 --test-coverage-branches=70 --test test/browser-protocol.test.mjs",
     "check:js": "node --check front/chat/chat.js && node --check front/chat/ui.js && node --check front/chat/state.js && node --check front/chat/format.js && node --check dashboard/app.js && node --check front/lobby.js",
     "check:web": "npm run check:js && npm run test:browser"
+  },
+  "devDependencies": {
+    "ws": "8.21.3"
   }
 }

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './test/playwright',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'line',
+  use: {
+    browserName: 'chromium',
+    headless: true,
+    trace: 'retain-on-failure',
+  },
+});

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -7,6 +7,7 @@ readonly dockerfile="$root/Dockerfile"
 rg -q '^USER conspire:conspire$' "$dockerfile"
 rg -q 'TLS_FILE_PRIVATE_KEY=/run/certs/privkey.pem' "$dockerfile"
 rg -q 'TLS_FILE_CERT_CHAIN=/run/certs/fullchain.pem' "$dockerfile"
+rg -q '^ENTRYPOINT \["/app/conspire", "--tls"\]$' "$dockerfile"
 if rg -qi 'newkey|privkey\.pem.*COPY|libressl-dev|cmake|ninja|g\+\+' "$dockerfile"; then
   printf '%s\n' 'runtime Dockerfile contains a key-generation, key-copy, or build-tool pattern' >&2
   exit 1

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -130,7 +130,7 @@ if(CONSPIRE_HAS_NATIVE_DEPS)
   src/utils/Statistics.cpp src/utils/Statistics.hpp
   src/dto/DTOs.hpp src/dto/Config.hpp)
   target_include_directories(conspire-lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
-  target_compile_definitions(conspire-lib PRIVATE
+  target_compile_definitions(conspire-lib PUBLIC
   CERT_PEM_PATH="cert/privkey.pem" CERT_CRT_PATH="cert/fullchain.pem"
   FRONT_PATH="front" CONSPIRE_VERSION="${CONSPIRE_VERSION}")
   target_link_libraries(conspire-lib
@@ -140,9 +140,6 @@ if(CONSPIRE_HAS_NATIVE_DEPS)
   conspire_enable_warnings(conspire-lib)
 
   add_executable(conspire-exe src/App.cpp)
-  target_compile_definitions(conspire-exe PRIVATE
-  CERT_PEM_PATH="cert/privkey.pem" CERT_CRT_PATH="cert/fullchain.pem"
-  FRONT_PATH="front" CONSPIRE_VERSION="${CONSPIRE_VERSION}")
   target_link_libraries(conspire-exe PRIVATE conspire-lib)
   conspire_apply_sanitizer(conspire-exe)
   conspire_enable_warnings(conspire-exe)

--- a/server/src/App.cpp
+++ b/server/src/App.cpp
@@ -74,10 +74,11 @@ void run(const oatpp::base::CommandLineArguments& args) {
 Conspire Chat Server v)HELP" << CONSPIRE_VERSION << R"HELP(
 Usage: conspire [options]
 Options:
-  --host <address>         Bind address (default: localhost)
-  --port <port>            Port to listen on (default: 8080)
-  --tls-key <path>         Path to TLS private key file (default: "privkey.pem")
-  --tls-chain <path>       Path to TLS certificate chain file (default: "fullchain.pem")
+  --host <hostname>        Public hostname (default: localhost)
+  --port <port>            Port to listen on (default: 8080; TLS: 8443)
+  --tls                    Enable TLS and load certificate files
+  --tls-key <path>         Path to TLS private key file (default: "cert/privkey.pem")
+  --tls-chain <path>       Path to TLS certificate chain file (default: "cert/fullchain.pem")
   --url-stats <path>       Statistics endpoint path (default: admin/stats.json)
   --pid <path>             Path to PID file to create
   --front <path>           Path to frontend static files (default: front)
@@ -91,6 +92,7 @@ Options:
   AppComponent components(args);
 
   OATPP_COMPONENT(oatpp::Object<ConfigDto>, appConfig);
+  OATPP_COMPONENT(std::shared_ptr<oatpp::async::Executor>, executor);
 
   // Setup signal handlers
   setupSignalHandlers();
@@ -99,6 +101,8 @@ Options:
   const std::string pidFilePath = appConfig->pidFilePath ? *appConfig->pidFilePath : "";
   if (!pidFile.create(pidFilePath)) {
     OATPP_LOGe("conspire", "Failed to create PID file: {}", pidFilePath);
+    executor->stop();
+    executor->join();
     return; // Exit if PID file creation failed
   }
   if (pidFile.active()) OATPP_LOGi("conspire", "Created PID file: {}", pidFilePath);
@@ -141,6 +145,9 @@ Options:
     statisticsRunner.stop();
     server.stop();
     if (serverThread.joinable()) serverThread.join();
+    connectionHandler->stop();
+    executor->stop();
+    executor->join();
     return;
   }
 
@@ -167,6 +174,10 @@ Options:
   statisticsRunner.stop();
   server.stop();
   if (serverThread.joinable()) serverThread.join();
+  connectionHandler->stop();
+  executor->waitTasksFinished(std::chrono::seconds(5));
+  executor->stop();
+  executor->join();
   pidFile.reset();
 
   OATPP_LOGi("conspire", "Server shutdown complete");

--- a/server/src/controller/StaticController.hpp
+++ b/server/src/controller/StaticController.hpp
@@ -34,8 +34,6 @@
 #include "oatpp/macro/codegen.hpp"
 #include "oatpp/macro/component.hpp"
 
-#include <regex>
-
 #include OATPP_CODEGEN_BEGIN(ApiController) /// <-- Begin Code-Gen
 
 class StaticController : public oatpp::web::server::api::ApiController {
@@ -51,6 +49,13 @@ private:
     OATPP_ASSERT_HTTP(buffer, Status::CODE_404, "File Not Found:(");
     return buffer;
   }
+
+  static std::string renderPage(oatpp::String file, const oatpp::String& version) {
+    std::string page = *file;
+    const auto title = conspire::boundaries::pageTitle(version ? *version : "unknown");
+    conspire::boundaries::replaceLiteral(page, "%%%CONSPIRE_TITLE%%%", title);
+    return page;
+  }
 public:
   StaticController(OATPP_COMPONENT(std::shared_ptr<ObjectMapper>, objectMapper))
     : oatpp::web::server::api::ApiController(objectMapper)
@@ -65,7 +70,8 @@ public:
       ++ controller->m_statistics->EVENT_FRONT_PAGE_LOADED;
       std::string filePath = controller->m_config->frontPath->c_str() + std::string("/index.html");
       auto fileCache = controller->loadFile(filePath.c_str());
-      auto response = controller->createResponse(Status::CODE_200, fileCache);
+      auto response = controller->createResponse(Status::CODE_200,
+                                                  controller->renderPage(fileCache, controller->m_config->version));
       response->putHeader(Header::CONTENT_TYPE, "text/html");
       response->putHeader("Content-Security-Policy", "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'");
       response->putHeader("X-Content-Type-Options", "nosniff");
@@ -95,8 +101,8 @@ public:
       const auto roomId = request->getPathVariable("roomId");
       OATPP_ASSERT_HTTP(roomId && conspire::boundaries::validRoomId(*roomId), Status::CODE_400, "Invalid room id");
       std::string filePath = controller->m_config->frontPath->c_str() + std::string("/chat/index.html");
-      std::string fileCache = *controller->loadFile(filePath.c_str());
-      auto text = std::regex_replace(fileCache, std::regex("%%%ROOM_ID%%%"), conspire::boundaries::urlPathSegment(*roomId));
+      auto text = controller->renderPage(controller->loadFile(filePath.c_str()), controller->m_config->version);
+      conspire::boundaries::replaceLiteral(text, "%%%ROOM_ID%%%", conspire::boundaries::urlPathSegment(*roomId));
       auto response = controller->createResponse(Status::CODE_200, text);
       response->putHeader(Header::CONTENT_TYPE, "text/html");
       response->putHeader("Content-Security-Policy", "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'");

--- a/server/src/dto/Config.hpp
+++ b/server/src/dto/Config.hpp
@@ -44,7 +44,7 @@ public:
 
   DTO_FIELD(String, host);
   DTO_FIELD(UInt16, port);
-  DTO_FIELD(Boolean, useTLS) = true;
+  DTO_FIELD(Boolean, useTLS) = false;
 
   /**
    * Path to TLS private key file.

--- a/server/src/dto/DTOs.hpp
+++ b/server/src/dto/DTOs.hpp
@@ -96,7 +96,7 @@ public:
 
 class StatPointDto : public oatpp::DTO {
 
-  DTO_INIT(StatPointDto, DTO);
+  DTO_INIT(StatPointDto, DTO)
 
   DTO_FIELD(Int64, timestamp);
 

--- a/server/src/utils/AppConfig.hpp
+++ b/server/src/utils/AppConfig.hpp
@@ -13,20 +13,23 @@ namespace conspire::config {
 
 inline oatpp::Object<ConfigDto> fromCommandLine(const oatpp::base::CommandLineArguments& arguments) {
   auto config = ConfigDto::createShared();
+  config->useTLS = arguments.hasArgument("--tls");
   config->host = std::getenv("EXTERNAL_ADDRESS");
   if (!config->host) config->host = arguments.getNamedArgumentValue("--host", "localhost");
   if (!config->host || !validHost(*config->host)) throw std::runtime_error("Invalid host!");
 
   const char* portText = std::getenv("EXTERNAL_PORT");
-  if (!portText) portText = arguments.getNamedArgumentValue("--port", "8443");
+  if (!portText) portText = arguments.getNamedArgumentValue("--port", config->useTLS ? "8443" : "8080");
   const auto port = parsePort(portText ? portText : "");
   if (!port) throw std::runtime_error("Invalid port!");
   config->port = *port;
 
-  config->tlsPrivateKeyPath = std::getenv("TLS_FILE_PRIVATE_KEY");
-  if (!config->tlsPrivateKeyPath) config->tlsPrivateKeyPath = arguments.getNamedArgumentValue("--tls-key", "" CERT_PEM_PATH);
-  config->tlsCertificateChainPath = std::getenv("TLS_FILE_CERT_CHAIN");
-  if (!config->tlsCertificateChainPath) config->tlsCertificateChainPath = arguments.getNamedArgumentValue("--tls-chain", "" CERT_CRT_PATH);
+  if (config->useTLS) {
+    config->tlsPrivateKeyPath = std::getenv("TLS_FILE_PRIVATE_KEY");
+    if (!config->tlsPrivateKeyPath) config->tlsPrivateKeyPath = arguments.getNamedArgumentValue("--tls-key", "" CERT_PEM_PATH);
+    config->tlsCertificateChainPath = std::getenv("TLS_FILE_CERT_CHAIN");
+    if (!config->tlsCertificateChainPath) config->tlsCertificateChainPath = arguments.getNamedArgumentValue("--tls-chain", "" CERT_CRT_PATH);
+  }
   config->statisticsUrl = std::getenv("URL_STATS_PATH");
   if (!config->statisticsUrl) config->statisticsUrl = arguments.getNamedArgumentValue("--url-stats", "admin/stats.json");
   if (!config->statisticsUrl || !validStatsPath(*config->statisticsUrl)) throw std::runtime_error("Invalid statistics path!");

--- a/server/src/utils/ServerBoundaries.hpp
+++ b/server/src/utils/ServerBoundaries.hpp
@@ -164,6 +164,41 @@ inline std::string javascriptString(std::string_view value) {
   return result;
 }
 
+inline std::string htmlText(std::string_view value) {
+  std::string result;
+  result.reserve(value.size());
+  for (const char character : value) {
+    switch (character) {
+      case '&': result += "&amp;"; break;
+      case '<': result += "&lt;"; break;
+      case '>': result += "&gt;"; break;
+      case '"': result += "&quot;"; break;
+      case '\'': result += "&#39;"; break;
+      default: result.push_back(character);
+    }
+  }
+  return result;
+}
+
+inline std::string pageTitle(std::string_view version) {
+  if (!version.empty() && version.front() == 'v') version.remove_prefix(1);
+  return "Conspire v" + htmlText(version) + " by Dyne.org";
+}
+
+inline bool replaceLiteral(std::string& text, std::string_view marker,
+                           std::string_view replacement) {
+  if (marker.empty()) return false;
+  bool replaced = false;
+  std::size_t searchFrom = 0;
+  while (true) {
+    const auto position = text.find(marker, searchFrom);
+    if (position == std::string::npos) return replaced;
+    text.replace(position, marker.size(), replacement);
+    searchFrom = position + replacement.size();
+    replaced = true;
+  }
+}
+
 template <typename Collection>
 void retainLast(Collection& values, std::size_t maximum) {
   while (values.size() > maximum) values.pop_front();

--- a/server/test/core_tests.cpp
+++ b/server/test/core_tests.cpp
@@ -93,6 +93,15 @@ int main() {
   assert(!chunkRequest.accept(7, 1, 1));
   assert(conspire::boundaries::urlPathSegment("a b/\"") == "a%20b%2F%22");
   assert(conspire::boundaries::javascriptString("</script>\"\\\n") == "\"\\u003C/script\\u003E\\\"\\\\\\n\"");
+  assert(conspire::boundaries::htmlText("1<&\"'") == "1&lt;&amp;&quot;&#39;");
+  assert(conspire::boundaries::pageTitle("1.2.3") == "Conspire v1.2.3 by Dyne.org");
+  assert(conspire::boundaries::pageTitle("v1.2.3") == "Conspire v1.2.3 by Dyne.org");
+  std::string page = "<title>%%%CONSPIRE_TITLE%%%</title><p>%%%CONSPIRE_TITLE%%%</p>";
+  assert(conspire::boundaries::replaceLiteral(page, "%%%CONSPIRE_TITLE%%%",
+                                               conspire::boundaries::pageTitle("1.2.3")));
+  assert(page == "<title>Conspire v1.2.3 by Dyne.org</title>"
+                 "<p>Conspire v1.2.3 by Dyne.org</p>");
+  assert(!conspire::boundaries::replaceLiteral(page, "%%%MISSING%%%", "unused"));
   assert(coverageFixture(true) == 1);
 
   std::atomic<int> iterations{0};

--- a/server/test/tests.cpp
+++ b/server/test/tests.cpp
@@ -1,11 +1,49 @@
 
 #include "WSTest.hpp"
+#include "utils/AppConfig.hpp"
 
 #include "oatpp-test/UnitTest.hpp"
+#include <cassert>
+#include <cstdlib>
 #include <iostream>
 
+void runConfigTests() {
+  unsetenv("EXTERNAL_ADDRESS");
+  unsetenv("EXTERNAL_PORT");
+  unsetenv("TLS_FILE_PRIVATE_KEY");
+  unsetenv("TLS_FILE_CERT_CHAIN");
+  unsetenv("URL_STATS_PATH");
+
+  setenv("TLS_FILE_PRIVATE_KEY", "/missing/key.pem", 1);
+  setenv("TLS_FILE_CERT_CHAIN", "/missing/chain.pem", 1);
+  const char* plainArguments[] = {"conspire"};
+  const auto plainConfig = conspire::config::fromCommandLine(
+      oatpp::base::CommandLineArguments(1, plainArguments));
+  assert(!plainConfig->useTLS);
+  assert(plainConfig->host && *plainConfig->host == "localhost");
+  assert(plainConfig->port && *plainConfig->port == 8080);
+  assert(!plainConfig->tlsPrivateKeyPath);
+  assert(!plainConfig->tlsCertificateChainPath);
+  assert(*plainConfig->getCanonicalBaseUrl() == "http://localhost:8080");
+  assert(*plainConfig->getWebsocketBaseUrl() == "ws://localhost:8080");
+
+  unsetenv("TLS_FILE_PRIVATE_KEY");
+  unsetenv("TLS_FILE_CERT_CHAIN");
+  const char* tlsArguments[] = {
+      "conspire", "--tls", "--tls-key", "test-key.pem",
+      "--tls-chain", "test-chain.pem"};
+  const auto tlsConfig = conspire::config::fromCommandLine(
+      oatpp::base::CommandLineArguments(6, tlsArguments));
+  assert(tlsConfig->useTLS);
+  assert(tlsConfig->port && *tlsConfig->port == 8443);
+  assert(tlsConfig->tlsPrivateKeyPath && *tlsConfig->tlsPrivateKeyPath == "test-key.pem");
+  assert(tlsConfig->tlsCertificateChainPath && *tlsConfig->tlsCertificateChainPath == "test-chain.pem");
+  assert(*tlsConfig->getCanonicalBaseUrl() == "https://localhost:8443");
+  assert(*tlsConfig->getWebsocketBaseUrl() == "wss://localhost:8443");
+}
 
 void runTests() {
+  runConfigTests();
   OATPP_RUN_TEST(WSTest);
 }
 

--- a/test/e2e/chat-session.test.mjs
+++ b/test/e2e/chat-session.test.mjs
@@ -1,0 +1,243 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import WebSocket from 'ws';
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+const binary = resolve(root, process.env.CONSPIRE_E2E_BINARY ?? 'build/native-gcc/server/conspire-exe');
+const messageCode = Object.freeze({ info: 0, peerJoined: 1, peerMessage: 3 });
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+function withTimeout(promise, milliseconds, message, onTimeout = () => {}) {
+  return new Promise((resolveTimed, rejectTimed) => {
+    const timeout = setTimeout(() => {
+      onTimeout();
+      rejectTimed(new Error(message));
+    }, milliseconds);
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolveTimed(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        rejectTimed(error);
+      },
+    );
+  });
+}
+
+async function waitUntil(description, evaluate, timeoutMilliseconds = 5_000) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const value = await evaluate();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(25);
+  }
+  const suffix = lastError ? `: ${lastError.message}` : '';
+  throw new Error(`Timed out waiting for ${description}${suffix}`);
+}
+
+async function reservePort() {
+  const server = createServer();
+  await new Promise((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  const { port } = address;
+  await new Promise((resolveClose, rejectClose) => server.close((error) => {
+    if (error) rejectClose(error);
+    else resolveClose();
+  }));
+  return port;
+}
+
+function startConspire(port) {
+  const environment = { ...process.env };
+  for (const name of [
+    'EXTERNAL_ADDRESS', 'EXTERNAL_PORT', 'TLS_FILE_PRIVATE_KEY',
+    'TLS_FILE_CERT_CHAIN', 'URL_STATS_PATH',
+  ]) delete environment[name];
+
+  const child = spawn(binary, [
+    '--host', 'localhost', '--port', String(port), '--front', resolve(root, 'front'),
+  ], {
+    cwd: root,
+    env: environment,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let output = '';
+  const appendOutput = (chunk) => {
+    output = `${output}${chunk}`.slice(-64 * 1024);
+  };
+  child.stdout.on('data', appendOutput);
+  child.stderr.on('data', appendOutput);
+
+  let processError;
+  child.once('error', (error) => { processError = error; });
+  const exit = new Promise((resolveExit) => child.once('exit', (code, signal) => {
+    resolveExit({ code, signal });
+  }));
+  return { child, exit, getOutput: () => output, getProcessError: () => processError };
+}
+
+async function waitForServer(server, origin) {
+  await waitUntil('Conspire HTTP readiness', async () => {
+    if (server.getProcessError()) throw server.getProcessError();
+    if (server.child.exitCode !== null) throw new Error(`server exited with ${server.child.exitCode}`);
+    const response = await fetch(`${origin}/`, { signal: AbortSignal.timeout(500) });
+    return response.ok;
+  }, 10_000);
+}
+
+async function connectClient(url, origin) {
+  const socket = new WebSocket(url, { origin });
+  const messages = [];
+  const socketErrors = [];
+  socket.on('message', (payload) => {
+    try {
+      messages.push(JSON.parse(payload.toString()));
+    } catch (error) {
+      socketErrors.push(error);
+    }
+  });
+  socket.on('error', (error) => socketErrors.push(error));
+
+  await new Promise((resolveOpen, rejectOpen) => {
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off('open', onOpen);
+      socket.off('error', onConnectionError);
+      socket.off('unexpected-response', onUnexpectedResponse);
+    };
+    const rejectConnection = (error) => {
+      cleanup();
+      socket.terminate();
+      rejectOpen(error);
+    };
+    const onOpen = () => {
+      cleanup();
+      resolveOpen();
+    };
+    const onConnectionError = (error) => rejectConnection(error);
+    const onUnexpectedResponse = (_request, response) => {
+      response.resume();
+      rejectConnection(new Error(`WebSocket upgrade returned HTTP ${response.statusCode}`));
+    };
+    const timeout = setTimeout(
+      () => rejectConnection(new Error(`Timed out opening ${url}`)), 5_000);
+    socket.once('open', onOpen);
+    socket.once('error', onConnectionError);
+    socket.once('unexpected-response', onUnexpectedResponse);
+  });
+  return { socket, messages, socketErrors };
+}
+
+async function waitForMessage(client, description, predicate) {
+  return waitUntil(description, () => {
+    if (client.socketErrors.length > 0) throw client.socketErrors[0];
+    return client.messages.find(predicate);
+  });
+}
+
+async function sendJson(client, message) {
+  await new Promise((resolveSend, rejectSend) => client.socket.send(
+    JSON.stringify(message),
+    (error) => error ? rejectSend(error) : resolveSend(),
+  ));
+}
+
+async function closeClient(client) {
+  if (client.socket.readyState === WebSocket.CLOSED) return;
+  const closed = new Promise((resolveClose) => client.socket.once('close', resolveClose));
+  client.socket.close(1000);
+  await withTimeout(closed, 2_000, 'Timed out closing WebSocket client');
+}
+
+async function stopConspire(server) {
+  if (server.child.exitCode === null) server.child.kill('SIGTERM');
+  return withTimeout(server.exit, 7_000, 'Timed out stopping Conspire',
+    () => server.child.kill('SIGKILL'));
+}
+
+test('real server broadcasts chat messages and supplies room history', { timeout: 30_000 }, async () => {
+  const port = await reservePort();
+  const origin = `http://localhost:${port}`;
+  const websocketUrl = `ws://localhost:${port}/api/ws/room/e2e-room/`;
+  const server = startConspire(port);
+  const clients = [];
+  let scenarioError;
+
+  try {
+    await waitForServer(server, origin);
+
+    const first = await connectClient(websocketUrl, origin);
+    clients.push(first);
+    const firstInfo = await waitForMessage(first, 'first peer onboarding',
+      (message) => message.code === messageCode.info);
+    assert.equal(firstInfo.peers.length, 1);
+
+    const second = await connectClient(websocketUrl, origin);
+    clients.push(second);
+    const joined = await waitForMessage(first, 'second peer join announcement',
+      (message) => message.code === messageCode.peerJoined);
+    assert.equal(typeof joined.peerId, 'number');
+
+    const secondInfo = await waitForMessage(second, 'second peer onboarding',
+      (message) => message.code === messageCode.info);
+    assert.equal(secondInfo.peers.length, 2);
+
+    const chatText = `end-to-end-${Date.now()}`;
+    await sendJson(first, { code: messageCode.peerMessage, message: chatText });
+    const broadcast = await waitForMessage(second, 'chat broadcast',
+      (message) => message.code === messageCode.peerMessage && message.message === chatText);
+    assert.equal(typeof broadcast.peerId, 'number');
+    assert.equal(typeof broadcast.peerName, 'string');
+    assert.equal(typeof broadcast.timestamp, 'number');
+
+    const third = await connectClient(websocketUrl, origin);
+    clients.push(third);
+    const thirdInfo = await waitForMessage(third, 'third peer history',
+      (message) => message.code === messageCode.info);
+    assert.equal(thirdInfo.peers.length, 3);
+    assert(thirdInfo.history.some(
+      (message) => message.code === messageCode.peerMessage && message.message === chatText));
+  } catch (error) {
+    scenarioError = error;
+  }
+
+  for (const client of clients.reverse()) {
+    try {
+      await closeClient(client);
+    } catch (error) {
+      scenarioError ??= error;
+    }
+  }
+
+  let exit;
+  try {
+    exit = await stopConspire(server);
+  } catch (error) {
+    scenarioError ??= error;
+  }
+
+  const diagnostics = server.getOutput();
+  if (scenarioError) {
+    throw new Error(`${scenarioError.message}\nConspire output:\n${diagnostics}`, { cause: scenarioError });
+  }
+  assert.deepEqual(exit, { code: 0, signal: null }, `Conspire output:\n${diagnostics}`);
+});

--- a/test/playwright/chat-ui.spec.mjs
+++ b/test/playwright/chat-ui.spec.mjs
@@ -1,0 +1,162 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+const binary = resolve(root, process.env.CONSPIRE_E2E_BINARY ?? 'build/native-gcc/server/conspire-exe');
+const buildVersion = process.env.CONSPIRE_E2E_VERSION ?? 'e2e';
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+async function reservePort() {
+  const reservation = createServer();
+  await new Promise((resolveListen, rejectListen) => {
+    reservation.once('error', rejectListen);
+    reservation.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = reservation.address();
+  if (!address || typeof address === 'string') throw new Error('Unable to reserve a localhost port');
+  await new Promise((resolveClose, rejectClose) => reservation.close(
+    (error) => error ? rejectClose(error) : resolveClose(),
+  ));
+  return address.port;
+}
+
+function startConspire(port) {
+  const environment = { ...process.env };
+  for (const name of [
+    'EXTERNAL_ADDRESS', 'EXTERNAL_PORT', 'TLS_FILE_PRIVATE_KEY',
+    'TLS_FILE_CERT_CHAIN', 'URL_STATS_PATH',
+  ]) delete environment[name];
+
+  const child = spawn(binary, [
+    '--host', 'localhost', '--port', String(port), '--front', resolve(root, 'front'),
+  ], {
+    cwd: root,
+    env: environment,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let output = '';
+  const appendOutput = (chunk) => { output = `${output}${chunk}`.slice(-64 * 1024); };
+  child.stdout.on('data', appendOutput);
+  child.stderr.on('data', appendOutput);
+
+  let processError;
+  child.once('error', (error) => { processError = error; });
+  const exit = new Promise((resolveExit) => child.once('exit', (code, signal) => {
+    resolveExit({ code, signal });
+  }));
+  return { child, exit, getOutput: () => output, getProcessError: () => processError };
+}
+
+async function waitForServer(server, origin) {
+  const deadline = Date.now() + 10_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (server.getProcessError()) throw server.getProcessError();
+    if (server.child.exitCode !== null) {
+      throw new Error(`Conspire exited with ${server.child.exitCode}\n${server.getOutput()}`);
+    }
+    try {
+      const response = await fetch(origin, { signal: AbortSignal.timeout(500) });
+      if (response.ok) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(25);
+  }
+  throw new Error(`Timed out waiting for Conspire: ${lastError?.message ?? 'not ready'}`);
+}
+
+async function stopConspire(server) {
+  if (server.child.exitCode === null) server.child.kill('SIGTERM');
+  let timeoutId;
+  const timeout = new Promise((_, rejectTimeout) => {
+    timeoutId = setTimeout(() => {
+      server.child.kill('SIGKILL');
+      rejectTimeout(new Error('Timed out stopping Conspire'));
+    }, 7_000);
+  });
+  try {
+    return await Promise.race([server.exit, timeout]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+test('users chat through the browser UI and a newcomer receives history', async ({ browser }) => {
+  test.setTimeout(45_000);
+  const port = await reservePort();
+  const origin = `http://localhost:${port}`;
+  const roomUrl = `${origin}/room/playwright-room`;
+  const server = startConspire(port);
+  const contexts = [];
+  const pageErrors = [];
+  let scenarioError;
+
+  try {
+    await waitForServer(server, origin);
+
+    const openParticipant = async () => {
+      const context = await browser.newContext();
+      contexts.push(context);
+      const page = await context.newPage();
+      page.on('pageerror', (error) => pageErrors.push(error));
+      await page.goto(roomUrl);
+      await expect(page).toHaveTitle(`Conspire v${buildVersion} by Dyne.org`);
+      return page;
+    };
+
+    const first = await openParticipant();
+    await expect(first.locator('#participants_toggle #participant_count')).toHaveText('1');
+
+    const second = await openParticipant();
+    await expect(first.locator('#participants_toggle #participant_count')).toHaveText('2');
+    await expect(second.locator('#participants_toggle #participant_count')).toHaveText('2');
+
+    const chatText = `playwright-${Date.now()}`;
+    await first.getByPlaceholder('Type a message').fill(chatText);
+    await first.getByRole('button', { name: 'Send', exact: true }).click();
+    await expect(first.locator('.message-text', { hasText: chatText })).toBeVisible();
+    await expect(second.locator('.message-text', { hasText: chatText })).toBeVisible();
+
+    const third = await openParticipant();
+    await expect(third.locator('#participants_toggle #participant_count')).toHaveText('3');
+    await expect(third.locator('.message-text', { hasText: chatText })).toBeVisible();
+    expect(pageErrors, pageErrors.map((error) => error.message).join('\n')).toEqual([]);
+  } catch (error) {
+    scenarioError = error;
+  }
+
+  for (const context of contexts.reverse()) {
+    try {
+      await context.close();
+    } catch (error) {
+      scenarioError ??= error;
+    }
+  }
+
+  let exit;
+  try {
+    exit = await stopConspire(server);
+  } catch (error) {
+    scenarioError ??= error;
+  }
+
+  const diagnostics = server.getOutput();
+  if (scenarioError) {
+    const browserDiagnostics = pageErrors.length > 0
+      ? `\nBrowser errors:\n${pageErrors.map((error) => error.stack ?? error.message).join('\n')}`
+      : '';
+    throw new Error(
+      `${scenarioError.message}${browserDiagnostics}\nConspire output:\n${diagnostics}`,
+      { cause: scenarioError },
+    );
+  }
+  expect(exit, `Conspire output:\n${diagnostics}`).toEqual({ code: 0, signal: null });
+});

--- a/test/static-quality.test.mjs
+++ b/test/static-quality.test.mjs
@@ -12,6 +12,18 @@ test('shipped HTML keeps executable behavior in external modules', async () => {
   }
 });
 
+test('served pages expose the build-version title placeholder', async () => {
+  for (const file of ['front/index.html', 'front/chat/index.html']) {
+    const html = await readFile(new URL(`../${file}`, import.meta.url), 'utf8');
+    assert.match(html, /<title>%%%CONSPIRE_TITLE%%%<\/title>/, file);
+  }
+
+  const controller = await readFile(
+    new URL('../server/src/controller/StaticController.hpp', import.meta.url), 'utf8');
+  assert.match(controller, /pageTitle\(version/);
+  assert.match(controller, /replaceLiteral\(page, "%%%CONSPIRE_TITLE%%%"/);
+});
+
 test('server admission and malformed-message guards remain explicit', async () => {
   const lobby = await readFile(new URL('../server/src/rooms/Lobby.cpp', import.meta.url), 'utf8');
   const room = await readFile(new URL('../server/src/rooms/Room.cpp', import.meta.url), 'utf8');


### PR DESCRIPTION
## Summary

- run plain HTTP and WebSockets on localhost:8080 unless `--tls` is supplied
- avoid loading certificate paths in non-TLS mode while retaining explicit TLS container deployments
- render lobby and room titles as `Conspire vN.N.N by Dyne.org`
- stop and join the oatpp executor cleanly during shutdown
- exercise the real server with three WebSocket clients, broadcast, history, and clean teardown
- drive the served chat UI in three independent Playwright browser contexts
- verify browser participants, message delivery, room history, and the versioned title
- fix the strict-mode `peerId` initialization error exposed by the browser test
- build the vendored oatpp prefix and run both E2E layers in CI

## Verification

- `cmake --build --preset native-gcc` and `ctest --preset native-gcc` — 3/3 passed
- `npm run check:web` — 13/13 passed
- `npm run coverage:browser` — 95% lines, 93.94% branches
- `npm run test:e2e` — real protocol chat session passed
- `npm run test:e2e:browser` — three-browser UI chat session passed
- `./scripts/container-smoke.sh --verify-only`
- live HTTP smoke at `http://localhost:8080`, including room assets and `ws://localhost:8080` configuration