### PR TITLE
feat: persist statistics across restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV EXTERNAL_ADDRESS=localhost \
     EXTERNAL_PORT=8443 \
     TLS_FILE_PRIVATE_KEY=/run/certs/privkey.pem \
     TLS_FILE_CERT_CHAIN=/run/certs/fullchain.pem \
-    URL_STATS_PATH=admin/stats.json
+    URL_STATS_PATH=admin/stats.json \
+    STATS_STATE_PATH=/run/conspire/stats.json
 
 # Release automation supplies a verified binary with its web assets embedded.
 # Certificates are operator-mounted at /run/certs and are never copied.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sources are built locally; the incompatible public oatpp 1.3 line is never
 substituted.
 
 ```sh
-docker run --read-only --tmpfs /run/conspire:uid=100,gid=101 \
+docker run --read-only -v conspire-state:/run/conspire \
   -v "$PWD/cert:/run/certs:ro" -p 8443:8443 ghcr.io/dyne/conspire:latest
 ```
 
@@ -177,7 +177,7 @@ mkdir cert \
   -keyout cert/privkey.pem   -out cert/test_cert.crt   \
   -subj "/C=NL/ST=Netherlands/L=Amsterdam/O=Dyne.org/CN=dyne.org" \
 && cat cert/test_cert.crt cert/privkey.pem > cert/fullchain.pem \
-&& docker run --read-only --tmpfs /run/conspire:uid=100,gid=101 \
+&& docker run --read-only -v conspire-state:/run/conspire \
   -v "$PWD/cert:/run/certs:ro" -p 8443:8443 ghcr.io/dyne/conspire:latest
 ```
 
@@ -219,6 +219,13 @@ Conspire exposes statistics at `/admin/stats.json` and serves its embedded
 [dashboard](dashboard/) at `/dashboard`. The dashboard uses the running
 server's configured statistics endpoint and visualizes peer activity, room
 usage, and system metrics.
+
+Native runs keep statistics in memory unless `--stats-state <path>` or the
+equivalent `STATS_STATE_PATH` environment variable is configured; the container
+image enables it at `/run/conspire/stats.json`. With persistence enabled,
+Conspire validates and restores the retained history at startup, checkpoints it
+atomically every minute, and saves once more on graceful shutdown. The state
+directory must be writable by the service user.
 
 ## 💼 License
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -27,8 +27,8 @@ The landing page generates random room URLs and redirects users to Conspire.
 
 The container has no baked certificate or private key. Mount an operator-owned
 directory at `/run/certs:ro` containing `privkey.pem` and `fullchain.pem`, run
-the filesystem read-only, and give `/run/conspire` a writable tmpfs for the
-optional PID file:
+the filesystem read-only, and give `/run/conspire` a named volume for durable
+statistics state and the optional PID file:
 
 Build the image from the same verified CMake inputs used in review (not from an
 untracked `conspire` file):
@@ -42,7 +42,7 @@ currently unavailable in this checkout and public oatpp 1.3.x must not be used
 as a substitute.
 
 ```sh
-docker run --read-only --tmpfs /run/conspire:uid=100,gid=101 \
+docker run --read-only -v conspire-state:/run/conspire \
   -v /opt/conspire/cert:/run/certs:ro -p 8443:8443 \
   -e EXTERNAL_ADDRESS=your-domain.com -e EXTERNAL_PORT=8443 \
   ghcr.io/dyne/conspire:latest
@@ -103,6 +103,8 @@ Environment=EXTERNAL_ADDRESS=your-domain.com
 Environment=EXTERNAL_PORT=8443
 Environment=TLS_FILE_PRIVATE_KEY=cert/privkey.pem
 Environment=TLS_FILE_CERT_CHAIN=cert/fullchain.pem
+Environment=STATS_STATE_PATH=/var/lib/conspire/stats.json
+StateDirectory=conspire
 Restart=on-failure
 
 [Install]
@@ -130,6 +132,9 @@ sudo ufw allow 8443/tcp
 ### 5. Test
 
 Open `https://your-domain.com:8443` — you should see the Conspire interface.
+Statistics are checkpointed atomically every minute and during graceful
+shutdown. The service restores the retained history and cumulative counters
+from `/var/lib/conspire/stats.json` on its next start.
 
 ## Landing Page Integration
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -5,8 +5,10 @@
 Conspire is a C++ oatpp server with a build-time embedded browser client. Clients connect
 directly over TLS/WebSockets; the landing page is separately served static
 content. The server process owns the embedded assets, ephemeral rooms, file streams, and the
-statistics endpoint. TLS private keys, release credentials, and deployment
-configuration are operator-owned inputs, not source or image assets.
+statistics endpoint. When configured, aggregate statistics history is atomically
+checkpointed to an operator-owned state path. TLS private keys, persistent
+state, release credentials, and deployment configuration are operator-owned
+inputs, not source or image assets.
 
 The main threat assumptions are hostile browser input, untrusted file names and
 sizes, malicious clients retaining connections, compromised package/action/image
@@ -71,6 +73,9 @@ advisory affects a pinned input.
   Dockerfile contract and record that a daemon was unavailable for image smoke.
 - Certificate errors: mount `privkey.pem` and `fullchain.pem` at `/run/certs`
   read-only; see the deployment guide for systemd paths.
+- Invalid statistics state: Conspire starts with empty in-memory statistics and
+  leaves the invalid file untouched. Move or repair it before restarting to
+  re-enable persistence at that path.
 - Before opening a PR: run every fresh-checkout command above, keep generated
   `dist/` and local certificates untracked, and update tests/documentation for
   observable behavior changes.

--- a/scripts/container-smoke.sh
+++ b/scripts/container-smoke.sh
@@ -7,6 +7,7 @@ readonly dockerfile="$root/Dockerfile"
 rg -q '^USER conspire:conspire$' "$dockerfile"
 rg -q 'TLS_FILE_PRIVATE_KEY=/run/certs/privkey.pem' "$dockerfile"
 rg -q 'TLS_FILE_CERT_CHAIN=/run/certs/fullchain.pem' "$dockerfile"
+rg -q 'STATS_STATE_PATH=/run/conspire/stats.json' "$dockerfile"
 rg -q '^ENTRYPOINT \["/app/conspire", "--tls"\]$' "$dockerfile"
 if rg -qi 'newkey|privkey\.pem.*COPY|libressl-dev|cmake|ninja|g\+\+' "$dockerfile"; then
   printf '%s\n' 'runtime Dockerfile contains a key-generation, key-copy, or build-tool pattern' >&2

--- a/server/src/App.cpp
+++ b/server/src/App.cpp
@@ -80,6 +80,7 @@ Options:
   --tls-key <path>         Path to TLS private key file (default: "cert/privkey.pem")
   --tls-chain <path>       Path to TLS certificate chain file (default: "cert/fullchain.pem")
   --url-stats <path>       Statistics endpoint path (default: admin/stats.json)
+  --stats-state <path>     Persist statistics to this file across restarts
   --pid <path>             Path to PID file to create
   --version                Show version information
   -h, --help               Show this help message
@@ -126,6 +127,20 @@ Options:
 
   OATPP_COMPONENT(std::shared_ptr<Lobby>, lobby);
   OATPP_COMPONENT(std::shared_ptr<Statistics>, statistics);
+  const std::string statisticsStatePath = appConfig->statisticsStatePath
+      ? *appConfig->statisticsStatePath : "";
+  bool statisticsPersistenceEnabled = !statisticsStatePath.empty();
+  if (statisticsPersistenceEnabled) {
+    const auto loadResult = statistics->loadState(statisticsStatePath);
+    if (loadResult == Statistics::StateLoadResult::LOADED) {
+      OATPP_LOGi("conspire", "Restored statistics state from {}", statisticsStatePath);
+    } else if (loadResult == Statistics::StateLoadResult::INVALID) {
+      OATPP_LOGw("conspire",
+          "Statistics state is invalid or unreadable; starting empty and preserving {}",
+          statisticsStatePath);
+      statisticsPersistenceEnabled = false;
+    }
+  }
   statistics->runStatIteration();
 
   std::thread serverThread([&server]{
@@ -134,16 +149,26 @@ Options:
 
   conspire::lifecycle::PeriodicRunner pingRunner;
   conspire::lifecycle::PeriodicRunner statisticsRunner;
+  conspire::lifecycle::PeriodicRunner statisticsPersistenceRunner;
   const bool pingStarted = pingRunner.start(std::chrono::seconds(30), [lobby] {
     lobby->runPingIteration();
   });
   const bool statisticsStarted = statisticsRunner.start(std::chrono::seconds(1), [statistics] {
     statistics->runStatIteration();
   });
-  if (!pingStarted || !statisticsStarted) {
+  const bool statisticsPersistenceStarted = !statisticsPersistenceEnabled ||
+      statisticsPersistenceRunner.start(std::chrono::minutes(1),
+          [statistics, statisticsStatePath] {
+            if (!statistics->saveState(statisticsStatePath)) {
+              OATPP_LOGw("conspire", "Failed to checkpoint statistics state to {}",
+                         statisticsStatePath);
+            }
+          });
+  if (!pingStarted || !statisticsStarted || !statisticsPersistenceStarted) {
     OATPP_LOGe("conspire", "Failed to start lifecycle workers");
     pingRunner.stop();
     statisticsRunner.stop();
+    statisticsPersistenceRunner.stop();
     server.stop();
     if (serverThread.joinable()) serverThread.join();
     connectionHandler->stop();
@@ -164,7 +189,8 @@ Options:
   OATPP_LOGi("conspire", "statistics URL={}", appConfig->getStatsUrl())
 
   // Wait for shutdown signal
-  while (g_shutdownSignal == 0 && !pingRunner.failed() && !statisticsRunner.failed()) {
+  while (g_shutdownSignal == 0 && !pingRunner.failed() && !statisticsRunner.failed() &&
+         !statisticsPersistenceRunner.failed()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
   }
 
@@ -172,11 +198,18 @@ Options:
 
   // Each owned worker is woken and joined before components/environment die.
   pingRunner.stop();
-  statisticsRunner.stop();
+  statisticsPersistenceRunner.stop();
   server.stop();
   if (serverThread.joinable()) serverThread.join();
   connectionHandler->stop();
   executor->waitTasksFinished(std::chrono::seconds(5));
+  statisticsRunner.stop();
+  if (statisticsPersistenceEnabled) {
+    statistics->runStatIteration();
+    if (!statistics->saveState(statisticsStatePath)) {
+      OATPP_LOGw("conspire", "Failed to save statistics state to {}", statisticsStatePath);
+    }
+  }
   executor->stop();
   executor->join();
   pidFile.reset();

--- a/server/src/dto/Config.hpp
+++ b/server/src/dto/Config.hpp
@@ -42,6 +42,11 @@ public:
 
   DTO_FIELD(String, statisticsUrl);
 
+  /**
+   * Optional path used to persist statistics across process restarts.
+   */
+  DTO_FIELD(String, statisticsStatePath);
+
   DTO_FIELD(String, host);
   DTO_FIELD(UInt16, port);
   DTO_FIELD(Boolean, useTLS) = false;

--- a/server/src/utils/AppConfig.hpp
+++ b/server/src/utils/AppConfig.hpp
@@ -33,6 +33,16 @@ inline oatpp::Object<ConfigDto> fromCommandLine(const oatpp::base::CommandLineAr
   config->statisticsUrl = std::getenv("URL_STATS_PATH");
   if (!config->statisticsUrl) config->statisticsUrl = arguments.getNamedArgumentValue("--url-stats", "admin/stats.json");
   if (!config->statisticsUrl || !validStatsPath(*config->statisticsUrl)) throw std::runtime_error("Invalid statistics path!");
+  config->statisticsStatePath = std::getenv("STATS_STATE_PATH");
+  if (!config->statisticsStatePath) {
+    config->statisticsStatePath = arguments.getNamedArgumentValue("--stats-state");
+  }
+  if (arguments.hasArgument("--stats-state") && !config->statisticsStatePath) {
+    throw std::runtime_error("Missing statistics state path!");
+  }
+  if (config->statisticsStatePath && !validStateFilePath(*config->statisticsStatePath)) {
+    throw std::runtime_error("Invalid statistics state path!");
+  }
   config->pidFilePath = arguments.getNamedArgumentValue("--pid");
   config->version = CONSPIRE_VERSION;
   return config;

--- a/server/src/utils/ConfigValidation.hpp
+++ b/server/src/utils/ConfigValidation.hpp
@@ -30,6 +30,11 @@ inline bool validStatsPath(std::string_view path) {
   return conspire::boundaries::validRelativePath(path) && path.size() <= 128;
 }
 
+inline bool validStateFilePath(std::string_view path) {
+  return !path.empty() && path.size() <= 4096 &&
+         !conspire::boundaries::containsControl(path);
+}
+
 inline std::string canonicalBaseUrl(std::string_view host, std::uint16_t port, bool useTls) {
   const auto defaultPort = useTls ? 443 : 80;
   std::string url = useTls ? "https://" : "http://";

--- a/server/src/utils/Statistics.cpp
+++ b/server/src/utils/Statistics.cpp
@@ -26,6 +26,70 @@
 
 #include "Statistics.hpp"
 
+#include <cerrno>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string_view>
+#include <vector>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace {
+
+constexpr std::size_t MAX_STATE_BYTES = 1024 * 1024;
+constexpr std::size_t MAX_STATE_POINTS = 1000;
+
+bool validPoint(const oatpp::Object<StatPointDto>& point) {
+  return point && point->timestamp && point->evFrontpageLoaded &&
+         point->evPeerConnected && point->evPeerDisconnected &&
+         point->evPeerZombieDropped && point->evPeerSendMessage &&
+         point->evPeerShareFile && point->evRoomCreated &&
+         point->evRoomDeleted && point->fileServedBytes &&
+         *point->timestamp > 0;
+}
+
+bool writeAll(int descriptor, std::string_view data) {
+  std::size_t written = 0;
+  while (written < data.size()) {
+    const auto result = ::write(descriptor, data.data() + written, data.size() - written);
+    if (result < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (result == 0) return false;
+    written += static_cast<std::size_t>(result);
+  }
+  return true;
+}
+
+bool writeAtomically(const std::string& path, std::string_view data) {
+  std::vector<char> temporary(path.begin(), path.end());
+  constexpr std::string_view suffix = ".tmp.XXXXXX";
+  temporary.insert(temporary.end(), suffix.begin(), suffix.end());
+  temporary.push_back('\0');
+
+  const int descriptor = ::mkstemp(temporary.data());
+  if (descriptor < 0) return false;
+
+  bool success = writeAll(descriptor, data);
+  if (success && ::fsync(descriptor) != 0) success = false;
+  if (::close(descriptor) != 0) success = false;
+  if (success && ::rename(temporary.data(), path.c_str()) != 0) success = false;
+  if (success) {
+    const auto parent = std::filesystem::path(path).parent_path();
+    const auto directory = parent.empty() ? std::filesystem::path(".") : parent;
+    const int directoryDescriptor = ::open(directory.c_str(), O_RDONLY | O_DIRECTORY);
+    if (directoryDescriptor < 0 || ::fsync(directoryDescriptor) != 0) success = false;
+    if (directoryDescriptor >= 0 && ::close(directoryDescriptor) != 0) success = false;
+  }
+  if (!success) ::unlink(temporary.data());
+  return success;
+}
+
+} // namespace
+
 void Statistics::takeSample() {
 
   auto maxPeriodMicro = m_maxPeriod.count();
@@ -77,6 +141,76 @@ void Statistics::takeSample() {
 oatpp::String Statistics::getJsonData() {
   std::lock_guard<std::mutex> guard(m_dataLock);
   return m_objectMapper.writeToString(m_dataPoints);
+}
+
+Statistics::StateLoadResult Statistics::loadState(const std::string& path) {
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input) {
+    std::error_code error;
+    const bool exists = std::filesystem::exists(path, error);
+    return !error && !exists ? StateLoadResult::MISSING : StateLoadResult::INVALID;
+  }
+
+  const auto end = input.tellg();
+  const auto stateSize = static_cast<std::streamoff>(end);
+  if (stateSize <= 0 || stateSize > static_cast<std::streamoff>(MAX_STATE_BYTES)) {
+    return StateLoadResult::INVALID;
+  }
+  std::string content(static_cast<std::size_t>(stateSize), '\0');
+  input.seekg(0, std::ios::beg);
+  if (!input.read(content.data(), static_cast<std::streamsize>(content.size()))) {
+    return StateLoadResult::INVALID;
+  }
+
+  oatpp::List<oatpp::Object<StatPointDto>> loaded;
+  try {
+    loaded = m_objectMapper.readFromString<oatpp::List<oatpp::Object<StatPointDto>>>(
+        content.c_str());
+  } catch (...) {
+    return StateLoadResult::INVALID;
+  }
+  if (!loaded || loaded->empty() || loaded->size() > MAX_STATE_POINTS) {
+    return StateLoadResult::INVALID;
+  }
+
+  v_int64 previousTimestamp = 0;
+  for (const auto& point : *loaded) {
+    if (!validPoint(point) || *point->timestamp < previousTimestamp) {
+      return StateLoadResult::INVALID;
+    }
+    previousTimestamp = *point->timestamp;
+  }
+
+  const auto& latest = loaded->back();
+  EVENT_FRONT_PAGE_LOADED.store(*latest->evFrontpageLoaded);
+  EVENT_PEER_CONNECTED.store(*latest->evPeerConnected);
+  EVENT_PEER_DISCONNECTED.store(*latest->evPeerDisconnected);
+  EVENT_PEER_ZOMBIE_DROPPED.store(*latest->evPeerZombieDropped);
+  EVENT_PEER_SEND_MESSAGE.store(*latest->evPeerSendMessage);
+  EVENT_PEER_SHARE_FILE.store(*latest->evPeerShareFile);
+  EVENT_ROOM_CREATED.store(*latest->evRoomCreated);
+  EVENT_ROOM_DELETED.store(*latest->evRoomDeleted);
+  FILE_SERVED_BYTES.store(*latest->fileServedBytes);
+
+  const auto nowMicro = oatpp::Environment::getMicroTickCount();
+  const auto oldestTimestamp = nowMicro - m_maxPeriod.count();
+  auto retained = oatpp::List<oatpp::Object<StatPointDto>>::createShared();
+  for (const auto& point : *loaded) {
+    if (*point->timestamp >= oldestTimestamp && *point->timestamp <= nowMicro) {
+      retained->push_back(point);
+    }
+  }
+
+  std::lock_guard<std::mutex> guard(m_dataLock);
+  m_dataPoints = std::move(retained);
+  return StateLoadResult::LOADED;
+}
+
+bool Statistics::saveState(const std::string& path) {
+  if (path.empty()) return false;
+  const auto json = getJsonData();
+  if (!json || json->empty() || json->size() > MAX_STATE_BYTES) return false;
+  return writeAtomically(path, *json);
 }
 
 void Statistics::runStatIteration() {

--- a/server/src/utils/Statistics.hpp
+++ b/server/src/utils/Statistics.hpp
@@ -31,10 +31,19 @@
 #include "oatpp/json/ObjectMapper.hpp"
 #include "oatpp/Types.hpp"
 
+#include <atomic>
 #include <chrono>
+#include <mutex>
+#include <string>
 
 class Statistics {
 public:
+
+  enum class StateLoadResult {
+    LOADED,
+    MISSING,
+    INVALID
+  };
 
   std::atomic<v_uint64> EVENT_FRONT_PAGE_LOADED   {0};          // On Frontpage Loaded
 
@@ -70,6 +79,8 @@ public:
 
   void takeSample();
   oatpp::String getJsonData();
+  StateLoadResult loadState(const std::string& path);
+  bool saveState(const std::string& path);
 
   /** Take one statistics sample. Scheduling and cancellation belong to an
    * owned lifecycle runner, not this component. */

--- a/server/test/core_tests.cpp
+++ b/server/test/core_tests.cpp
@@ -39,6 +39,10 @@ int main() {
   assert(conspire::config::validStatsPath("admin/stats.json"));
   assert(!conspire::config::validStatsPath("../stats.json"));
   assert(!conspire::config::validStatsPath("/stats.json"));
+  assert(conspire::config::validStateFilePath("/var/lib/conspire/stats.json"));
+  assert(conspire::config::validStateFilePath("relative stats.json"));
+  assert(!conspire::config::validStateFilePath(""));
+  assert(!conspire::config::validStateFilePath("stats\n.json"));
   assert(conspire::boundaries::validRequestPath("/room/one"));
   assert(!conspire::boundaries::validRequestPath("//evil.test"));
   assert(!conspire::boundaries::validRequestPath("/room\r\none"));

--- a/server/test/tests.cpp
+++ b/server/test/tests.cpp
@@ -1,11 +1,16 @@
 
 #include "WSTest.hpp"
 #include "utils/AppConfig.hpp"
+#include "utils/Statistics.hpp"
 
 #include "oatpp-test/UnitTest.hpp"
 #include <cassert>
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
+
+#include <unistd.h>
 
 void runConfigTests() {
   unsetenv("EXTERNAL_ADDRESS");
@@ -13,6 +18,7 @@ void runConfigTests() {
   unsetenv("TLS_FILE_PRIVATE_KEY");
   unsetenv("TLS_FILE_CERT_CHAIN");
   unsetenv("URL_STATS_PATH");
+  unsetenv("STATS_STATE_PATH");
 
   setenv("TLS_FILE_PRIVATE_KEY", "/missing/key.pem", 1);
   setenv("TLS_FILE_CERT_CHAIN", "/missing/chain.pem", 1);
@@ -26,6 +32,24 @@ void runConfigTests() {
   assert(!plainConfig->tlsCertificateChainPath);
   assert(*plainConfig->getCanonicalBaseUrl() == "http://localhost:8080");
   assert(*plainConfig->getWebsocketBaseUrl() == "ws://localhost:8080");
+  assert(!plainConfig->statisticsStatePath);
+
+  const char* persistentArguments[] = {
+      "conspire", "--stats-state", "/var/lib/conspire/stats.json"};
+  const auto persistentConfig = conspire::config::fromCommandLine(
+      oatpp::base::CommandLineArguments(3, persistentArguments));
+  assert(persistentConfig->statisticsStatePath &&
+         *persistentConfig->statisticsStatePath == "/var/lib/conspire/stats.json");
+
+  const char* missingStatePathArguments[] = {"conspire", "--stats-state"};
+  bool missingStatePathRejected = false;
+  try {
+    static_cast<void>(conspire::config::fromCommandLine(
+        oatpp::base::CommandLineArguments(2, missingStatePathArguments)));
+  } catch (const std::runtime_error&) {
+    missingStatePathRejected = true;
+  }
+  assert(missingStatePathRejected);
 
   unsetenv("TLS_FILE_PRIVATE_KEY");
   unsetenv("TLS_FILE_CERT_CHAIN");
@@ -42,8 +66,42 @@ void runConfigTests() {
   assert(*tlsConfig->getWebsocketBaseUrl() == "wss://localhost:8443");
 }
 
+void runStatisticsPersistenceTests() {
+  const auto statePath = std::filesystem::temp_directory_path() /
+      ("conspire-statistics-test-" + std::to_string(getpid()) + ".json");
+  std::filesystem::remove(statePath);
+
+  Statistics source;
+  assert(source.loadState(statePath.string()) == Statistics::StateLoadResult::MISSING);
+  source.EVENT_FRONT_PAGE_LOADED.store(17);
+  source.EVENT_PEER_CONNECTED.store(9);
+  source.EVENT_PEER_SEND_MESSAGE.store(23);
+  source.FILE_SERVED_BYTES.store(4096);
+  source.runStatIteration();
+  assert(source.saveState(statePath.string()));
+
+  const auto permissions = std::filesystem::status(statePath).permissions();
+  assert((permissions & std::filesystem::perms::group_all) == std::filesystem::perms::none);
+  assert((permissions & std::filesystem::perms::others_all) == std::filesystem::perms::none);
+
+  Statistics restored;
+  assert(restored.loadState(statePath.string()) == Statistics::StateLoadResult::LOADED);
+  assert(restored.EVENT_FRONT_PAGE_LOADED.load() == 17);
+  assert(restored.EVENT_PEER_CONNECTED.load() == 9);
+  assert(restored.EVENT_PEER_SEND_MESSAGE.load() == 23);
+  assert(restored.FILE_SERVED_BYTES.load() == 4096);
+
+  {
+    std::ofstream invalid(statePath, std::ios::binary | std::ios::trunc);
+    invalid << "not-json";
+  }
+  assert(restored.loadState(statePath.string()) == Statistics::StateLoadResult::INVALID);
+  std::filesystem::remove(statePath);
+}
+
 void runTests() {
   runConfigTests();
+  runStatisticsPersistenceTests();
   OATPP_RUN_TEST(WSTest);
 }
 

--- a/test/e2e/chat-session.test.mjs
+++ b/test/e2e/chat-session.test.mjs
@@ -3,8 +3,9 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import WebSocket from 'ws';
 
 const root = fileURLToPath(new URL('../..', import.meta.url));
@@ -224,6 +225,72 @@ test('real server serves its embedded dashboard and configured statistics path',
         { cause: scenarioError });
     }
     assert.deepEqual(exit, { code: 0, signal: null }, `Conspire output:\n${diagnostics}`);
+  });
+
+test('statistics survive a graceful process restart', { timeout: 30_000 }, async () => {
+  const stateDirectory = await mkdtemp(join(tmpdir(), 'conspire-statistics-e2e-'));
+  const statePath = join(stateDirectory, 'stats.json');
+  let activeServer;
+  let scenarioError;
+
+  try {
+    const firstPort = await reservePort();
+    const firstOrigin = `http://localhost:${firstPort}`;
+    activeServer = startConspire(firstPort, ['--stats-state', statePath]);
+    await waitForServer(activeServer, firstOrigin);
+    await fetch(`${firstOrigin}/`);
+    await fetch(`${firstOrigin}/`);
+    assert.deepEqual(await stopConspire(activeServer), { code: 0, signal: null });
+    activeServer = undefined;
+
+    const savedBeforeRestart = JSON.parse(await readFile(statePath, 'utf8'));
+    assert(savedBeforeRestart.length > 0);
+    const beforeRestart = savedBeforeRestart.at(-1);
+    assert(beforeRestart.ev_front_page_loaded >= 2);
+
+    const secondPort = await reservePort();
+    const secondOrigin = `http://localhost:${secondPort}`;
+    activeServer = startConspire(secondPort, ['--stats-state', statePath]);
+    await waitForServer(activeServer, secondOrigin);
+    const restored = await (await fetch(`${secondOrigin}/admin/stats.json`)).json();
+    assert(restored.length > 0);
+    assert(restored.at(-1).ev_front_page_loaded >= beforeRestart.ev_front_page_loaded);
+    assert(restored.some((point) => point.timestamp === beforeRestart.timestamp));
+  } catch (error) {
+    scenarioError = error;
+  }
+
+  if (activeServer) {
+    try {
+      const exit = await stopConspire(activeServer);
+      assert.deepEqual(exit, { code: 0, signal: null });
+    } catch (error) {
+      scenarioError ??= error;
+    }
+  }
+  await rm(stateDirectory, { recursive: true, force: true });
+
+  if (scenarioError) throw scenarioError;
+});
+
+test('invalid statistics state is preserved without blocking startup',
+  { timeout: 30_000 }, async () => {
+    const stateDirectory = await mkdtemp(join(tmpdir(), 'conspire-invalid-statistics-e2e-'));
+    const statePath = join(stateDirectory, 'stats.json');
+    const invalidState = '{not valid json';
+    await writeFile(statePath, invalidState);
+    const port = await reservePort();
+    const origin = `http://localhost:${port}`;
+    const server = startConspire(port, ['--stats-state', statePath]);
+
+    try {
+      await waitForServer(server, origin);
+      assert.deepEqual(await stopConspire(server), { code: 0, signal: null });
+      assert.equal(await readFile(statePath, 'utf8'), invalidState);
+    } finally {
+      if (server.child.exitCode === null) await stopConspire(server);
+      await rm(stateDirectory, { recursive: true, force: true });
+    }
   });
 
 test('real server broadcasts chat messages and supplies room history', { timeout: 30_000 }, async () => {


### PR DESCRIPTION
## Summary

- add opt-in native persistence through `--stats-state` or `STATS_STATE_PATH`
- validate and restore retained seven-day history and cumulative counters at startup
- checkpoint to an atomic mode-0600 file every minute and after request processing stops during graceful shutdown
- preserve invalid state files unchanged while allowing the server to start with empty statistics
- configure the container image to use `/run/conspire/stats.json` and document named-volume/systemd state directories

## Verification

- static GCC/musl `make` build with ccache
- `cmake --build --preset native-gcc && ctest --preset native-gcc` — 3/3 passed
- `npm run test:e2e` — 4/4 passed, including a real two-process persistence restart and invalid-state preservation
- `npm run test:e2e:browser` — passed
- `npm run check:web` — 14/14 passed
- `npm run coverage:browser` — 95% lines, 93.94% branches
- `./scripts/check-release-contract.sh`
- `./scripts/container-smoke.sh --verify-only`
- `./scripts/run-static-analysis.sh`

## Known toolchain note

The optional Clang preset is still blocked by oatpp 1.4 variadic macros triggering Clang 19 C++20-extension diagnostics under `-Werror`; the GCC/native and release GCC/musl paths pass.