### PR TITLE
feat: add persistent Tor onion service

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,25 @@ TLS is opt-in. Pass `--tls` together with certificate paths when it is needed:
   --tls-key cert/privkey.pem --tls-chain cert/fullchain.pem
 ```
 
+At startup Conspire also probes `/run/tor/control`, then the loopback control
+port `127.0.0.1:9051`. If Tor offers SAFECOOKIE (or permission-protected NULL
+authentication), Conspire registers a v3 onion service on public port 80. The
+homepage then exposes a **Tor hidden service** button and requests through that
+hostname use an onion-safe WebSocket origin. The returned ED25519 key is stored
+at `--tor-key`; by default it is `onion.key` beside `--stats-state`, or
+`conspire-onion.key` in the working directory when no state path is configured.
+Use `--no-tor` to disable probing. With clearnet TLS, `--tor-backend-port`
+(default 8080) is a separate plaintext listener bound only to `127.0.0.1`.
+
+Tor registration is best-effort: an absent or inaccessible daemon is logged and
+does not prevent the clearnet server from starting. See the
+[deployment guide](docs/DEPLOYMENT.md#tor-onion-service) for ControlSocket and
+service-account configuration.
+
 The real-process tests start this native binary on isolated localhost ports.
 The protocol test connects three WebSocket clients, verifies broadcast and room
-history, and checks clean shutdown. The Playwright test drives the served UI in
+history, exercises SAFECOOKIE/ADD_ONION against a fake Tor controller, verifies
+stable onion identity across restart, and checks clean shutdown. The Playwright test drives the served UI in
 three independent browser contexts and verifies the versioned title,
 participants, message delivery, and history without TLS:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -28,7 +28,7 @@ The landing page generates random room URLs and redirects users to Conspire.
 The container has no baked certificate or private key. Mount an operator-owned
 directory at `/run/certs:ro` containing `privkey.pem` and `fullchain.pem`, run
 the filesystem read-only, and give `/run/conspire` a named volume for durable
-statistics state and the optional PID file:
+statistics state, the onion identity key, and the optional PID file:
 
 Build the image from the same verified CMake inputs used in review (not from an
 untracked `conspire` file):
@@ -91,12 +91,13 @@ Create `/etc/systemd/system/conspire.service`:
 ```ini
 [Unit]
 Description=Conspire - Ephemeral Anonymous Chat
-After=network.target
+After=network.target tor.service
 
 [Service]
 Type=simple
 User=conspire
 Group=conspire
+SupplementaryGroups=debian-tor
 WorkingDirectory=/opt/conspire
 ExecStart=/opt/conspire/conspire --tls
 Environment=EXTERNAL_ADDRESS=your-domain.com
@@ -104,6 +105,7 @@ Environment=EXTERNAL_PORT=8443
 Environment=TLS_FILE_PRIVATE_KEY=cert/privkey.pem
 Environment=TLS_FILE_CERT_CHAIN=cert/fullchain.pem
 Environment=STATS_STATE_PATH=/var/lib/conspire/stats.json
+Environment=TOR_KEY_PATH=/var/lib/conspire/onion.key
 StateDirectory=conspire
 Restart=on-failure
 
@@ -135,6 +137,45 @@ Open `https://your-domain.com:8443` — you should see the Conspire interface.
 Statistics are checkpointed atomically every minute and during graceful
 shutdown. The service restores the retained history and cumulative counters
 from `/var/lib/conspire/stats.json` on its next start.
+
+## Tor onion service
+
+Conspire automatically tries a Tor Unix control socket first and
+`127.0.0.1:9051` second. A typical Debian/Ubuntu Tor configuration in
+`/etc/tor/torrc` is:
+
+```text
+ControlSocket /run/tor/control
+ControlSocketsGroupWritable 1
+CookieAuthentication 1
+CookieAuthFileGroupReadable 1
+```
+
+Restart Tor after changing `torrc`, add the `conspire` service account to the
+Tor control-socket group (commonly `debian-tor`), and keep the
+`SupplementaryGroups` setting in the systemd unit. Conspire prefers SAFECOOKIE;
+it deliberately refuses deprecated COOKIE-only authentication. A
+permission-protected control socket advertising NULL authentication is also
+supported.
+
+On first registration Tor returns an ED25519-V3 private key. Conspire writes it
+atomically with mode 0600 to `TOR_KEY_PATH`/`--tor-key` and reuses it after
+restart, preserving the onion address. An invalid or unreadable existing key is
+left untouched and disables Tor integration for that run. On graceful shutdown
+Conspire sends `DEL_ONION`; the saved identity remains available for the next
+start, but Tor does not advertise a dead backend while Conspire is stopped.
+
+The public onion service defaults to port 80. In the TLS deployment above Tor
+forwards it to a second plaintext HTTP listener at `127.0.0.1:8080`; only the
+clearnet TLS port needs a firewall rule. Change these with
+`TOR_VIRTUAL_PORT`/`--tor-virtual-port` and
+`TOR_BACKEND_PORT`/`--tor-backend-port`. Without `--tls`, Tor forwards to the
+existing HTTP listener instead.
+
+To use a non-default control endpoint, set `TOR_CONTROL_SOCKET`,
+`TOR_CONTROL_HOST`, or `TOR_CONTROL_PORT` (equivalent CLI options are listed by
+`conspire --help`). TCP control is restricted to a loopback host. Use
+`--no-tor` when onion registration is intentionally disabled.
 
 ## Landing Page Integration
 
@@ -210,6 +251,12 @@ For infrastructure-as-code deployment, see [conspire-infra](https://github.com/s
 | `EXTERNAL_PORT` | 8080 (8443 with `--tls`) | HTTP/WebSocket port |
 | `TLS_FILE_PRIVATE_KEY` | — | Private key path, read only with `--tls` |
 | `TLS_FILE_CERT_CHAIN` | — | Certificate-chain path, read only with `--tls` |
+| `TOR_CONTROL_SOCKET` | `/run/tor/control` | Preferred Tor Unix control socket |
+| `TOR_CONTROL_HOST` | `127.0.0.1` | Loopback Tor control fallback host |
+| `TOR_CONTROL_PORT` | `9051` | Loopback Tor control fallback port |
+| `TOR_KEY_PATH` | Beside statistics state, otherwise working directory | Persistent ED25519-V3 onion key |
+| `TOR_BACKEND_PORT` | `8080` | Loopback-only plaintext backend when TLS is active |
+| `TOR_VIRTUAL_PORT` | `80` | Public onion-service port |
 
 For a local certificate-free smoke test, run `./conspire` without TLS options
 and open <http://localhost:8080>. Use `./conspire --tls` for the certificate

--- a/front/index.html
+++ b/front/index.html
@@ -50,6 +50,7 @@
 
             <input id="public-room-button" type="button" value="Public Reception">
             <input id="private-room-button" type="button" value="New Private Room">
+            %%%TOR_HIDDEN_SERVICE_BUTTON%%%
         </div>
         <div id="note">
             <section aria-labelledby="rules-heading">

--- a/front/style.css
+++ b/front/style.css
@@ -20,13 +20,15 @@ body {
     margin: 0 0 50px 0;
 }
 
-input {
+input,
+.button {
     font-size: 36px;
     padding: 14px 20px;
     margin: 0 0 20px 0;
 }
 
-input {
+input,
+.button {
     display: inline;
     border: none;
     outline: none;
@@ -39,13 +41,16 @@ input {
     background-color: #448AFF;
     color: white;
     text-transform: uppercase;
+    text-decoration: none;
 }
 
-input:hover {
+input:hover,
+.button:hover {
     background-color: #2979FF;
 }
 
-input:active {
+input:active,
+.button:active {
     background-color: #2979FF;
 }
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -151,6 +151,7 @@ if(CONSPIRE_HAS_NATIVE_DEPS)
   src/rooms/Lobby.cpp src/rooms/Lobby.hpp
   src/utils/Nickname.cpp src/utils/Nickname.hpp
   src/utils/AppConfig.hpp src/utils/ConfigValidation.hpp src/utils/ServerBoundaries.hpp src/utils/Lifecycle.hpp
+  src/utils/TorControl.cpp src/utils/TorControl.hpp
   src/utils/Statistics.cpp src/utils/Statistics.hpp
   src/dto/DTOs.hpp src/dto/Config.hpp)
   target_include_directories(conspire-lib PUBLIC

--- a/server/src/App.cpp
+++ b/server/src/App.cpp
@@ -31,6 +31,7 @@
 
 #include "./AppComponent.hpp"
 #include "utils/Lifecycle.hpp"
+#include "utils/TorControl.hpp"
 
 #include "oatpp/network/Server.hpp"
 
@@ -38,6 +39,7 @@
 #include <csignal>
 #include <thread>
 #include <chrono>
+#include <memory>
 
 // The handler is deliberately limited to assigning a sig_atomic_t. Logging,
 // cleanup, and joining happen in run(), where ordinary C++ is safe.
@@ -81,6 +83,18 @@ Options:
   --tls-chain <path>       Path to TLS certificate chain file (default: "cert/fullchain.pem")
   --url-stats <path>       Statistics endpoint path (default: admin/stats.json)
   --stats-state <path>     Persist statistics to this file across restarts
+  --no-tor                 Disable automatic Tor onion-service registration
+  --tor-control-socket <path>
+                           Tor ControlSocket (default: /run/tor/control)
+  --tor-control-host <host>
+                           Loopback fallback control host (default: 127.0.0.1)
+  --tor-control-port <port>
+                           Loopback fallback control port (default: 9051)
+  --tor-key <path>         Persistent ED25519-V3 onion key file
+  --tor-backend-port <port>
+                           Loopback HTTP port used with clearnet TLS (default: 8080)
+  --tor-virtual-port <port>
+                           Public onion-service port (default: 80)
   --pid <path>             Path to PID file to create
   --version                Show version information
   -h, --help               Show this help message
@@ -125,6 +139,44 @@ Options:
   /* Create server which takes provided TCP connections and passes them to HTTP connection handler */
   oatpp::network::Server server(connectionProvider, connectionHandler);
 
+  conspire::tor::OnionService onionService;
+  std::shared_ptr<oatpp::network::ServerConnectionProvider> torConnectionProvider;
+  std::unique_ptr<oatpp::network::Server> torServer;
+  if (appConfig->torEnabled) {
+    try {
+      if (appConfig->useTLS) {
+        torConnectionProvider =
+            oatpp::network::tcp::server::ConnectionProvider::createShared(
+                {"127.0.0.1", appConfig->torBackendPort,
+                 oatpp::network::Address::IP_4});
+      }
+      conspire::tor::Options torOptions;
+      torOptions.controlSocket = *appConfig->torControlSocket;
+      torOptions.controlHost = *appConfig->torControlHost;
+      torOptions.controlPort = *appConfig->torControlPort;
+      torOptions.keyPath = *appConfig->torKeyPath;
+      torOptions.targetPort = *appConfig->torBackendPort;
+      torOptions.virtualPort = *appConfig->torVirtualPort;
+      std::string torError;
+      if (onionService.start(torOptions, torError)) {
+        appConfig->onionHost = onionService.hostname();
+        if (torConnectionProvider) {
+          torServer = std::make_unique<oatpp::network::Server>(
+              torConnectionProvider, connectionHandler);
+        }
+        OATPP_LOGi("conspire", "Tor hidden service registered at {} via {}",
+                   appConfig->getOnionBaseUrl(), onionService.controlEndpoint())
+      } else {
+        torConnectionProvider.reset();
+        OATPP_LOGw("conspire", "Tor integration unavailable: {}", torError)
+      }
+    } catch (const std::exception& exception) {
+      onionService.stop();
+      torConnectionProvider.reset();
+      OATPP_LOGw("conspire", "Tor integration unavailable: {}", exception.what())
+    }
+  }
+
   OATPP_COMPONENT(std::shared_ptr<Lobby>, lobby);
   OATPP_COMPONENT(std::shared_ptr<Statistics>, statistics);
   const std::string statisticsStatePath = appConfig->statisticsStatePath
@@ -146,6 +198,10 @@ Options:
   std::thread serverThread([&server]{
     server.run();
   });
+  std::thread torServerThread;
+  if (torServer) {
+    torServerThread = std::thread([&torServer] { torServer->run(); });
+  }
 
   conspire::lifecycle::PeriodicRunner pingRunner;
   conspire::lifecycle::PeriodicRunner statisticsRunner;
@@ -169,6 +225,9 @@ Options:
     pingRunner.stop();
     statisticsRunner.stop();
     statisticsPersistenceRunner.stop();
+    onionService.stop();
+    if (torServer) torServer->stop();
+    if (torServerThread.joinable()) torServerThread.join();
     server.stop();
     if (serverThread.joinable()) serverThread.join();
     connectionHandler->stop();
@@ -187,6 +246,9 @@ Options:
 
   OATPP_LOGi("conspire", "canonical base URL={}", appConfig->getCanonicalBaseUrl())
   OATPP_LOGi("conspire", "statistics URL={}", appConfig->getStatsUrl())
+  if (appConfig->onionHost) {
+    OATPP_LOGi("conspire", "Tor hidden service URL={}", appConfig->getOnionBaseUrl())
+  }
 
   // Wait for shutdown signal
   while (g_shutdownSignal == 0 && !pingRunner.failed() && !statisticsRunner.failed() &&
@@ -199,6 +261,9 @@ Options:
   // Each owned worker is woken and joined before components/environment die.
   pingRunner.stop();
   statisticsPersistenceRunner.stop();
+  onionService.stop();
+  if (torServer) torServer->stop();
+  if (torServerThread.joinable()) torServerThread.join();
   server.stop();
   if (serverThread.joinable()) serverThread.join();
   connectionHandler->stop();

--- a/server/src/AppComponent.hpp
+++ b/server/src/AppComponent.hpp
@@ -63,12 +63,11 @@ private:
 
     std::shared_ptr<OutgoingResponse> intercept(const std::shared_ptr<IncomingRequest>& request) override {
       auto host = request->getHeader(oatpp::web::protocol::http::Header::HOST);
-      auto siteHost = componentAppConfig->getHostString();
       const auto path = request->getStartingLine().path.toString();
       if(!host || !conspire::boundaries::validHost(*host) || !conspire::boundaries::validRequestPath(*path)) {
         return OutgoingResponse::createShared(oatpp::web::protocol::http::Status::CODE_400, nullptr);
       }
-      if(!host || host != siteHost) {
+      if(!componentAppConfig->isAllowedRequestHost(*host)) {
         auto response = OutgoingResponse::createShared(oatpp::web::protocol::http::Status::CODE_301, nullptr);
         response->putHeader("Location", componentAppConfig->getCanonicalBaseUrl() + path);
         response->putHeader("Cache-Control", "no-store");

--- a/server/src/controller/RoomsController.hpp
+++ b/server/src/controller/RoomsController.hpp
@@ -66,7 +66,7 @@ public:
       OATPP_ASSERT_HTTP(roomName && conspire::boundaries::validRoomId(*roomName), Status::CODE_400, "Invalid room id");
       const auto origin = request->getHeader("Origin");
       const bool developmentOverride = std::getenv("CONSPIRE_ALLOW_DEV_ORIGIN") != nullptr;
-      OATPP_ASSERT_HTTP(origin && conspire::boundaries::allowedOrigin(*origin, *controller->appConfig->getCanonicalBaseUrl(), developmentOverride),
+      OATPP_ASSERT_HTTP(origin && controller->appConfig->isAllowedOrigin(*origin, developmentOverride),
                         Status::CODE_403, "Invalid origin");
       auto nickname = Nickname::random();
 

--- a/server/src/controller/StaticController.hpp
+++ b/server/src/controller/StaticController.hpp
@@ -51,10 +51,19 @@ private:
     return {asset.data(), static_cast<v_buff_size>(asset.size())};
   }
 
-  static std::string renderPage(oatpp::String file, const oatpp::String& version) {
+  static std::string renderPage(oatpp::String file, const oatpp::String& version,
+                                const oatpp::String& onionBaseUrl = nullptr) {
     std::string page = *file;
     const auto title = conspire::boundaries::pageTitle(version ? *version : "unknown");
     conspire::boundaries::replaceLiteral(page, "%%%CONSPIRE_TITLE%%%", title);
+    std::string onionButton;
+    if (onionBaseUrl) {
+      onionButton = "<a id=\"tor-hidden-service\" class=\"button\" href=\"" +
+          conspire::boundaries::htmlText(*onionBaseUrl) +
+          "\" target=\"_blank\" rel=\"noopener noreferrer\">Tor hidden service</a>";
+    }
+    conspire::boundaries::replaceLiteral(page,
+        "%%%TOR_HIDDEN_SERVICE_BUTTON%%%", onionButton);
     return page;
   }
 public:
@@ -70,7 +79,8 @@ public:
     Action act() override {
       ++ controller->m_statistics->EVENT_FRONT_PAGE_LOADED;
       auto response = controller->createResponse(Status::CODE_200,
-          controller->renderPage(controller->loadAsset("index.html"), controller->m_config->version));
+          controller->renderPage(controller->loadAsset("index.html"),
+              controller->m_config->version, controller->m_config->getOnionBaseUrl()));
       response->putHeader(Header::CONTENT_TYPE, "text/html");
       response->putHeader("Content-Security-Policy", "default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'");
       response->putHeader("X-Content-Type-Options", "nosniff");
@@ -218,7 +228,10 @@ public:
 
       oatpp::data::stream::BufferOutputStream stream;
 
-      const auto baseUrl = *controller->m_config->getWebsocketBaseUrl();
+      const auto requestHost = request->getHeader(Header::HOST);
+      OATPP_ASSERT_HTTP(requestHost && controller->m_config->isAllowedRequestHost(*requestHost),
+                        Status::CODE_400, "Invalid host");
+      const auto baseUrl = *controller->m_config->getWebsocketBaseUrlForHost(*requestHost);
       const auto encodedRoom = conspire::boundaries::urlPathSegment(*roomId);
       const auto websocketUrl = conspire::boundaries::javascriptString(baseUrl + "/api/ws/room/" + encodedRoom);
       const auto roomUrl = conspire::boundaries::javascriptString("/room/" + encodedRoom);

--- a/server/src/dto/Config.hpp
+++ b/server/src/dto/Config.hpp
@@ -33,6 +33,8 @@
 #include "oatpp/data/stream/BufferStream.hpp"
 #include "utils/ConfigValidation.hpp"
 
+#include <string_view>
+
 #include OATPP_CODEGEN_BEGIN(DTO)
 
 class ConfigDto : public oatpp::DTO {
@@ -50,6 +52,15 @@ public:
   DTO_FIELD(String, host);
   DTO_FIELD(UInt16, port);
   DTO_FIELD(Boolean, useTLS) = false;
+
+  DTO_FIELD(Boolean, torEnabled) = true;
+  DTO_FIELD(String, torControlSocket);
+  DTO_FIELD(String, torControlHost);
+  DTO_FIELD(UInt16, torControlPort);
+  DTO_FIELD(String, torKeyPath);
+  DTO_FIELD(UInt16, torBackendPort);
+  DTO_FIELD(UInt16, torVirtualPort);
+  DTO_FIELD(String, onionHost);
 
   /**
    * Path to TLS private key file.
@@ -109,6 +120,47 @@ public:
 
   oatpp::String getStatsUrl() {
     return getCanonicalBaseUrl() + "/" + statisticsUrl;
+  }
+
+  oatpp::String getOnionHostString() const {
+    if (!onionHost) return nullptr;
+    std::string value = *onionHost;
+    if (torVirtualPort && *torVirtualPort != 80) {
+      value += ":" + std::to_string(*torVirtualPort);
+    }
+    return value;
+  }
+
+  oatpp::String getOnionBaseUrl() const {
+    if (!onionHost) return nullptr;
+    return conspire::config::canonicalBaseUrl(*onionHost,
+        torVirtualPort ? *torVirtualPort : 80, false);
+  }
+
+  bool isAllowedRequestHost(std::string_view requestHost) {
+    if (requestHost == std::string_view(*getHostString())) return true;
+    const auto onion = getOnionHostString();
+    return onion && requestHost == std::string_view(*onion);
+  }
+
+  bool isOnionRequestHost(std::string_view requestHost) const {
+    const auto onion = getOnionHostString();
+    return onion && requestHost == std::string_view(*onion);
+  }
+
+  oatpp::String getWebsocketBaseUrlForHost(std::string_view requestHost) {
+    if (isOnionRequestHost(requestHost)) {
+      return conspire::config::websocketBaseUrl(*onionHost,
+          torVirtualPort ? *torVirtualPort : 80, false);
+    }
+    return getWebsocketBaseUrl();
+  }
+
+  bool isAllowedOrigin(std::string_view origin, bool developmentOverride) {
+    if (conspire::boundaries::allowedOrigin(origin, *getCanonicalBaseUrl(),
+                                             developmentOverride)) return true;
+    const auto onion = getOnionBaseUrl();
+    return onion && origin == std::string_view(*onion);
   }
 
 };

--- a/server/src/utils/AppConfig.hpp
+++ b/server/src/utils/AppConfig.hpp
@@ -7,6 +7,7 @@
 #include "oatpp/base/CommandLineArguments.hpp"
 
 #include <cstdlib>
+#include <filesystem>
 #include <stdexcept>
 
 namespace conspire::config {
@@ -42,6 +43,77 @@ inline oatpp::Object<ConfigDto> fromCommandLine(const oatpp::base::CommandLineAr
   }
   if (config->statisticsStatePath && !validStateFilePath(*config->statisticsStatePath)) {
     throw std::runtime_error("Invalid statistics state path!");
+  }
+
+  config->torEnabled = !arguments.hasArgument("--no-tor");
+  config->torControlSocket = std::getenv("TOR_CONTROL_SOCKET");
+  if (!config->torControlSocket) {
+    config->torControlSocket = arguments.getNamedArgumentValue(
+        "--tor-control-socket", "/run/tor/control");
+  }
+  if (arguments.hasArgument("--tor-control-socket") && !config->torControlSocket) {
+    throw std::runtime_error("Missing Tor control socket path!");
+  }
+  if (config->torControlSocket && !validStateFilePath(*config->torControlSocket)) {
+    throw std::runtime_error("Invalid Tor control socket path!");
+  }
+
+  config->torControlHost = std::getenv("TOR_CONTROL_HOST");
+  if (!config->torControlHost) {
+    config->torControlHost = arguments.getNamedArgumentValue(
+        "--tor-control-host", "127.0.0.1");
+  }
+  if (!config->torControlHost || !validLoopbackHost(*config->torControlHost)) {
+    throw std::runtime_error("Tor control host must be loopback!");
+  }
+  const char* torControlPortText = std::getenv("TOR_CONTROL_PORT");
+  if (!torControlPortText) {
+    torControlPortText = arguments.getNamedArgumentValue("--tor-control-port", "9051");
+  }
+  const auto torControlPort = parsePort(torControlPortText ? torControlPortText : "");
+  if (!torControlPort || *torControlPort == 0) {
+    throw std::runtime_error("Invalid Tor control port!");
+  }
+  config->torControlPort = *torControlPort;
+
+  const char* torBackendPortText = std::getenv("TOR_BACKEND_PORT");
+  std::string defaultTorBackendPort(portText);
+  if (config->useTLS) {
+    defaultTorBackendPort = *config->port == 8080 ? "8081" : "8080";
+  }
+  if (!torBackendPortText) {
+    torBackendPortText = arguments.getNamedArgumentValue(
+        "--tor-backend-port", defaultTorBackendPort.c_str());
+  }
+  const auto torBackendPort = parsePort(torBackendPortText ? torBackendPortText : "");
+  if (!torBackendPort || (config->torEnabled && (*torBackendPort == 0 ||
+      (config->useTLS && *torBackendPort == *config->port)))) {
+    throw std::runtime_error("Invalid Tor backend port!");
+  }
+  config->torBackendPort = *torBackendPort;
+
+  const char* torVirtualPortText = std::getenv("TOR_VIRTUAL_PORT");
+  if (!torVirtualPortText) {
+    torVirtualPortText = arguments.getNamedArgumentValue("--tor-virtual-port", "80");
+  }
+  const auto torVirtualPort = parsePort(torVirtualPortText ? torVirtualPortText : "");
+  if (!torVirtualPort || *torVirtualPort == 0) {
+    throw std::runtime_error("Invalid Tor virtual port!");
+  }
+  config->torVirtualPort = *torVirtualPort;
+
+  config->torKeyPath = std::getenv("TOR_KEY_PATH");
+  if (!config->torKeyPath) config->torKeyPath = arguments.getNamedArgumentValue("--tor-key");
+  if (arguments.hasArgument("--tor-key") && !config->torKeyPath) {
+    throw std::runtime_error("Missing Tor key path!");
+  }
+  if (!config->torKeyPath && config->statisticsStatePath) {
+    config->torKeyPath = (std::filesystem::path(*config->statisticsStatePath)
+        .parent_path() / "onion.key").string();
+  }
+  if (!config->torKeyPath) config->torKeyPath = "conspire-onion.key";
+  if (!validStateFilePath(*config->torKeyPath)) {
+    throw std::runtime_error("Invalid Tor key path!");
   }
   config->pidFilePath = arguments.getNamedArgumentValue("--pid");
   config->version = CONSPIRE_VERSION;

--- a/server/src/utils/ConfigValidation.hpp
+++ b/server/src/utils/ConfigValidation.hpp
@@ -35,6 +35,10 @@ inline bool validStateFilePath(std::string_view path) {
          !conspire::boundaries::containsControl(path);
 }
 
+inline bool validLoopbackHost(std::string_view host) {
+  return host == "127.0.0.1" || host == "::1" || host == "localhost";
+}
+
 inline std::string canonicalBaseUrl(std::string_view host, std::uint16_t port, bool useTls) {
   const auto defaultPort = useTls ? 443 : 80;
   std::string url = useTls ? "https://" : "http://";

--- a/server/src/utils/TorControl.cpp
+++ b/server/src/utils/TorControl.cpp
@@ -1,0 +1,668 @@
+#include "TorControl.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cctype>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+
+namespace conspire::tor {
+namespace {
+
+constexpr std::size_t MAX_LINE_BYTES = 8192;
+constexpr std::size_t MAX_REPLY_BYTES = 64 * 1024;
+constexpr std::size_t COOKIE_BYTES = 32;
+constexpr std::size_t NONCE_BYTES = 32;
+constexpr std::string_view SERVER_HASH_KEY =
+    "Tor safe cookie authentication server-to-controller hash";
+constexpr std::string_view CLIENT_HASH_KEY =
+    "Tor safe cookie authentication controller-to-server hash";
+
+class Descriptor {
+private:
+  int m_value = -1;
+public:
+  explicit Descriptor(int value = -1) : m_value(value) {}
+  Descriptor(const Descriptor&) = delete;
+  Descriptor& operator=(const Descriptor&) = delete;
+  ~Descriptor() { if (m_value >= 0) ::close(m_value); }
+  int get() const { return m_value; }
+  int release() { const int value = m_value; m_value = -1; return value; }
+};
+
+std::string socketError(std::string_view action) {
+  return std::string(action) + ": " + std::strerror(errno);
+}
+
+bool waitForConnect(int descriptor, std::chrono::milliseconds timeout,
+                    std::string& error) {
+  pollfd event{descriptor, POLLOUT, 0};
+  const auto timeoutCount = timeout.count();
+  const int boundedTimeout = timeoutCount > 30000 ? 30000 :
+      timeoutCount < 1 ? 1 : static_cast<int>(timeoutCount);
+  int result;
+  do {
+    result = ::poll(&event, 1, boundedTimeout);
+  } while (result < 0 && errno == EINTR);
+  if (result == 0) {
+    error = "Tor control connection timed out";
+    return false;
+  }
+  if (result < 0) {
+    error = socketError("polling Tor control connection");
+    return false;
+  }
+  int socketStatus = 0;
+  socklen_t statusSize = sizeof(socketStatus);
+  if (::getsockopt(descriptor, SOL_SOCKET, SO_ERROR, &socketStatus, &statusSize) != 0) {
+    error = socketError("checking Tor control connection");
+    return false;
+  }
+  if (socketStatus != 0) {
+    error = "connecting to Tor control endpoint: " +
+        std::string(std::strerror(socketStatus));
+    return false;
+  }
+  return true;
+}
+
+bool connectWithTimeout(int descriptor, const sockaddr* address,
+                        socklen_t addressSize, std::chrono::milliseconds timeout,
+                        std::string& error) {
+  const int flags = ::fcntl(descriptor, F_GETFL, 0);
+  if (flags < 0 || ::fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) != 0) {
+    error = socketError("configuring Tor control socket");
+    return false;
+  }
+  int result;
+  do {
+    result = ::connect(descriptor, address, addressSize);
+  } while (result < 0 && errno == EINTR);
+  if (result < 0 && errno != EINPROGRESS) {
+    error = socketError("connecting to Tor control endpoint");
+    return false;
+  }
+  if (result < 0 && !waitForConnect(descriptor, timeout, error)) return false;
+  if (::fcntl(descriptor, F_SETFL, flags) != 0) {
+    error = socketError("restoring Tor control socket flags");
+    return false;
+  }
+
+  const auto seconds = timeout.count() / 1000;
+  const auto microseconds = (timeout.count() % 1000) * 1000;
+  timeval socketTimeout{static_cast<time_t>(seconds),
+                        static_cast<suseconds_t>(microseconds)};
+  if (::setsockopt(descriptor, SOL_SOCKET, SO_RCVTIMEO, &socketTimeout,
+                   sizeof(socketTimeout)) != 0 ||
+      ::setsockopt(descriptor, SOL_SOCKET, SO_SNDTIMEO, &socketTimeout,
+                   sizeof(socketTimeout)) != 0) {
+    error = socketError("setting Tor control socket timeout");
+    return false;
+  }
+  return true;
+}
+
+std::optional<int> connectUnix(std::string_view path,
+                               std::chrono::milliseconds timeout,
+                               std::string& error) {
+  if (path.empty() || path.size() >= sizeof(sockaddr_un::sun_path)) {
+    error = "Tor control socket path is empty or too long";
+    return std::nullopt;
+  }
+  Descriptor descriptor(::socket(AF_UNIX, SOCK_STREAM, 0));
+  if (descriptor.get() < 0) {
+    error = socketError("creating Tor Unix control socket");
+    return std::nullopt;
+  }
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::memcpy(address.sun_path, path.data(), path.size());
+  address.sun_path[path.size()] = '\0';
+  if (!connectWithTimeout(descriptor.get(), reinterpret_cast<sockaddr*>(&address),
+                          sizeof(address), timeout, error)) return std::nullopt;
+  return descriptor.release();
+}
+
+std::optional<int> connectTcp(std::string_view host, std::uint16_t port,
+                              std::chrono::milliseconds timeout,
+                              std::string& error) {
+  addrinfo hints{};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = IPPROTO_TCP;
+  addrinfo* addresses = nullptr;
+  const auto service = std::to_string(port);
+  const std::string hostString(host);
+  const int lookup = ::getaddrinfo(hostString.c_str(), service.c_str(), &hints,
+                                   &addresses);
+  if (lookup != 0) {
+    error = "resolving Tor control host: " + std::string(gai_strerror(lookup));
+    return std::nullopt;
+  }
+  std::unique_ptr<addrinfo, decltype(&::freeaddrinfo)> owned(addresses,
+                                                             ::freeaddrinfo);
+  for (auto* address = addresses; address; address = address->ai_next) {
+    Descriptor descriptor(::socket(address->ai_family, address->ai_socktype,
+                                   address->ai_protocol));
+    if (descriptor.get() < 0) continue;
+    std::string candidateError;
+    if (connectWithTimeout(descriptor.get(), address->ai_addr,
+                           static_cast<socklen_t>(address->ai_addrlen), timeout,
+                           candidateError)) return descriptor.release();
+    error = std::move(candidateError);
+  }
+  if (error.empty()) error = "no usable Tor control address";
+  return std::nullopt;
+}
+
+std::string hexEncode(const unsigned char* data, std::size_t size) {
+  static constexpr char HEX[] = "0123456789ABCDEF";
+  std::string encoded(size * 2, '0');
+  for (std::size_t index = 0; index < size; ++index) {
+    encoded[index * 2] = HEX[data[index] >> 4];
+    encoded[index * 2 + 1] = HEX[data[index] & 0x0f];
+  }
+  return encoded;
+}
+
+std::optional<std::vector<unsigned char>> hexDecode(std::string_view text) {
+  if (text.empty() || text.size() % 2 != 0) return std::nullopt;
+  std::vector<unsigned char> decoded(text.size() / 2);
+  const auto nibble = [](char character) -> int {
+    if (character >= '0' && character <= '9') return character - '0';
+    if (character >= 'a' && character <= 'f') return character - 'a' + 10;
+    if (character >= 'A' && character <= 'F') return character - 'A' + 10;
+    return -1;
+  };
+  for (std::size_t index = 0; index < decoded.size(); ++index) {
+    const int high = nibble(text[index * 2]);
+    const int low = nibble(text[index * 2 + 1]);
+    if (high < 0 || low < 0) return std::nullopt;
+    decoded[index] = static_cast<unsigned char>((high << 4) | low);
+  }
+  return decoded;
+}
+
+std::array<unsigned char, EVP_MAX_MD_SIZE> hmacSha256(
+    std::string_view key, const std::vector<unsigned char>& message,
+    unsigned int& outputSize) {
+  std::array<unsigned char, EVP_MAX_MD_SIZE> output{};
+  HMAC(EVP_sha256(), key.data(), static_cast<int>(key.size()), message.data(),
+       message.size(), output.data(), &outputSize);
+  return output;
+}
+
+std::optional<std::string> quotedValue(std::string_view line,
+                                       std::string_view name) {
+  const auto start = line.find(name);
+  if (start == std::string_view::npos) return std::nullopt;
+  std::size_t position = start + name.size();
+  if (position >= line.size() || line[position] != '"') return std::nullopt;
+  ++position;
+  std::string value;
+  while (position < line.size()) {
+    const char character = line[position++];
+    if (character == '"') return value;
+    if (character != '\\') {
+      value.push_back(character);
+      continue;
+    }
+    if (position >= line.size()) return std::nullopt;
+    const char escaped = line[position++];
+    switch (escaped) {
+      case 'n': value.push_back('\n'); break;
+      case 'r': value.push_back('\r'); break;
+      case 't': value.push_back('\t'); break;
+      case '\\': value.push_back('\\'); break;
+      case '"': value.push_back('"'); break;
+      default:
+        if (escaped < '0' || escaped > '7') {
+          value.push_back(escaped);
+          break;
+        }
+        unsigned int octet = static_cast<unsigned int>(escaped - '0');
+        for (int count = 1; count < 3 && position < line.size() &&
+             line[position] >= '0' && line[position] <= '7'; ++count) {
+          octet = octet * 8 + static_cast<unsigned int>(line[position++] - '0');
+        }
+        if (octet > 255) return std::nullopt;
+        value.push_back(static_cast<char>(octet));
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<std::array<unsigned char, COOKIE_BYTES>> readCookie(
+    const std::string& path) {
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input || input.tellg() != static_cast<std::streamoff>(COOKIE_BYTES)) {
+    return std::nullopt;
+  }
+  std::array<unsigned char, COOKIE_BYTES> cookie{};
+  input.seekg(0, std::ios::beg);
+  if (!input.read(reinterpret_cast<char*>(cookie.data()),
+                  static_cast<std::streamsize>(cookie.size()))) return std::nullopt;
+  return cookie;
+}
+
+bool writeAll(int descriptor, std::string_view content) {
+  std::size_t written = 0;
+  while (written < content.size()) {
+    const auto result = ::write(descriptor, content.data() + written,
+                                content.size() - written);
+    if (result < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (result == 0) return false;
+    written += static_cast<std::size_t>(result);
+  }
+  return true;
+}
+
+bool savePrivateKey(const std::string& path, std::string_view privateKey) {
+  if (path.empty() || !validPrivateKey(privateKey)) return false;
+  const auto parent = std::filesystem::path(path).parent_path();
+  std::error_code filesystemError;
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent, filesystemError);
+    if (filesystemError) return false;
+  }
+  std::vector<char> temporary(path.begin(), path.end());
+  constexpr std::string_view suffix = ".tmp.XXXXXX";
+  temporary.insert(temporary.end(), suffix.begin(), suffix.end());
+  temporary.push_back('\0');
+  const int descriptor = ::mkstemp(temporary.data());
+  if (descriptor < 0) return false;
+  const std::string content = std::string(privateKey) + '\n';
+  bool success = ::fchmod(descriptor, S_IRUSR | S_IWUSR) == 0 &&
+      writeAll(descriptor, content) && ::fsync(descriptor) == 0;
+  if (::close(descriptor) != 0) success = false;
+  if (success && ::rename(temporary.data(), path.c_str()) != 0) success = false;
+  if (!success) ::unlink(temporary.data());
+  return success;
+}
+
+enum class KeyLoadResult { MISSING, VALID, INVALID };
+
+KeyLoadResult loadPrivateKey(const std::string& path, std::string& privateKey) {
+  const int rawDescriptor = ::open(path.c_str(), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+  if (rawDescriptor < 0) {
+    return errno == ENOENT ? KeyLoadResult::MISSING : KeyLoadResult::INVALID;
+  }
+  Descriptor descriptor(rawDescriptor);
+  struct stat metadata {};
+  if (::fstat(descriptor.get(), &metadata) != 0 || !S_ISREG(metadata.st_mode) ||
+      (metadata.st_mode & 077) != 0 || metadata.st_size <= 0 ||
+      metadata.st_size > 1024) {
+    return KeyLoadResult::INVALID;
+  }
+  privateKey.assign(static_cast<std::size_t>(metadata.st_size), '\0');
+  std::size_t consumed = 0;
+  while (consumed < privateKey.size()) {
+    const auto result = ::read(descriptor.get(), privateKey.data() + consumed,
+                               privateKey.size() - consumed);
+    if (result < 0) {
+      if (errno == EINTR) continue;
+      return KeyLoadResult::INVALID;
+    }
+    if (result == 0) return KeyLoadResult::INVALID;
+    consumed += static_cast<std::size_t>(result);
+  }
+  while (!privateKey.empty() &&
+         (privateKey.back() == '\n' || privateKey.back() == '\r')) {
+    privateKey.pop_back();
+  }
+  return validPrivateKey(privateKey) ? KeyLoadResult::VALID :
+                                      KeyLoadResult::INVALID;
+}
+
+bool containsMethod(std::string_view methods, std::string_view method) {
+  std::size_t position = 0;
+  while (position <= methods.size()) {
+    const auto end = methods.find(',', position);
+    const auto token = methods.substr(position, end == std::string_view::npos ?
+        methods.size() - position : end - position);
+    if (token == method) return true;
+    if (end == std::string_view::npos) break;
+    position = end + 1;
+  }
+  return false;
+}
+
+std::string fieldValue(std::string_view line, std::string_view field) {
+  const auto start = line.find(field);
+  if (start == std::string_view::npos) return {};
+  const auto valueStart = start + field.size();
+  const auto end = line.find(' ', valueStart);
+  return std::string(line.substr(valueStart, end == std::string_view::npos ?
+      line.size() - valueStart : end - valueStart));
+}
+
+} // namespace
+
+bool validServiceId(std::string_view serviceId) {
+  if (serviceId.size() != 56) return false;
+  return std::all_of(serviceId.begin(), serviceId.end(), [](char character) {
+    return (character >= 'a' && character <= 'z') ||
+           (character >= '2' && character <= '7');
+  });
+}
+
+bool validPrivateKey(std::string_view privateKey) {
+  constexpr std::string_view prefix = "ED25519-V3:";
+  constexpr std::size_t encodedKeyBytes = 88;
+  if (privateKey.size() != prefix.size() + encodedKeyBytes ||
+      privateKey.substr(0, prefix.size()) != prefix ||
+      privateKey.substr(privateKey.size() - 2) != "==") return false;
+  const auto keyEnd = privateKey.end() - 2;
+  return std::all_of(privateKey.begin() + static_cast<std::ptrdiff_t>(prefix.size()),
+                     keyEnd, [](char character) {
+    return (character >= 'A' && character <= 'Z') ||
+           (character >= 'a' && character <= 'z') ||
+           (character >= '0' && character <= '9') || character == '+' ||
+           character == '/';
+  });
+}
+
+std::string replyValue(const Reply& reply, std::string_view prefix) {
+  for (const auto& line : reply.lines) {
+    if (line.compare(0, prefix.size(), prefix) == 0) {
+      return line.substr(prefix.size());
+    }
+  }
+  return {};
+}
+
+OnionService::~OnionService() { stop(); }
+
+bool OnionService::connectControl(const Options& options, std::string& error) {
+  std::string unixError;
+  if (!options.controlSocket.empty()) {
+    auto descriptor = connectUnix(options.controlSocket, options.timeout, unixError);
+    if (descriptor) {
+      m_descriptor = *descriptor;
+      m_controlEndpoint = "unix:" + options.controlSocket;
+      return true;
+    }
+  }
+  std::string tcpError;
+  auto descriptor = connectTcp(options.controlHost, options.controlPort,
+                               options.timeout, tcpError);
+  if (descriptor) {
+    m_descriptor = *descriptor;
+    m_controlEndpoint = "tcp:" + options.controlHost + ":" +
+        std::to_string(options.controlPort);
+    return true;
+  }
+  error = "Tor control unavailable";
+  if (!unixError.empty()) error += " (Unix: " + unixError + ")";
+  if (!tcpError.empty()) error += " (TCP: " + tcpError + ")";
+  return false;
+}
+
+bool OnionService::writeCommand(std::string_view command, std::string& error) {
+  if (command.empty() || command.size() > MAX_LINE_BYTES ||
+      command.find('\r') != std::string_view::npos ||
+      command.find('\n') != std::string_view::npos) {
+    error = "refusing invalid Tor control command";
+    return false;
+  }
+  const std::string framed = std::string(command) + "\r\n";
+  std::size_t written = 0;
+  while (written < framed.size()) {
+    const auto result = ::send(m_descriptor, framed.data() + written,
+                               framed.size() - written, MSG_NOSIGNAL);
+    if (result < 0) {
+      if (errno == EINTR) continue;
+      error = socketError("writing Tor control command");
+      return false;
+    }
+    if (result == 0) {
+      error = "Tor control connection closed while writing";
+      return false;
+    }
+    written += static_cast<std::size_t>(result);
+  }
+  return true;
+}
+
+bool OnionService::readLine(std::string& line, std::string& error) {
+  while (true) {
+    const auto lineEnd = m_readBuffer.find("\r\n");
+    if (lineEnd != std::string::npos) {
+      line = m_readBuffer.substr(0, lineEnd);
+      m_readBuffer.erase(0, lineEnd + 2);
+      return true;
+    }
+    if (m_readBuffer.size() >= MAX_LINE_BYTES) {
+      error = "Tor control reply line exceeds limit";
+      return false;
+    }
+    std::array<char, 2048> chunk{};
+    const auto received = ::recv(m_descriptor, chunk.data(), chunk.size(), 0);
+    if (received < 0) {
+      if (errno == EINTR) continue;
+      error = socketError("reading Tor control reply");
+      return false;
+    }
+    if (received == 0) {
+      error = "Tor control connection closed while reading";
+      return false;
+    }
+    m_readBuffer.append(chunk.data(), static_cast<std::size_t>(received));
+  }
+}
+
+bool OnionService::readReply(Reply& reply, std::string& error) {
+  reply = {};
+  std::size_t total = 0;
+  while (true) {
+    std::string line;
+    if (!readLine(line, error)) return false;
+    total += line.size();
+    if (total > MAX_REPLY_BYTES || line.size() < 4 ||
+        !std::isdigit(static_cast<unsigned char>(line[0])) ||
+        !std::isdigit(static_cast<unsigned char>(line[1])) ||
+        !std::isdigit(static_cast<unsigned char>(line[2]))) {
+      error = "malformed Tor control reply";
+      return false;
+    }
+    const int status = (line[0] - '0') * 100 + (line[1] - '0') * 10 +
+        (line[2] - '0');
+    if (reply.status == 0) reply.status = status;
+    if (status != reply.status || (line[3] != '-' && line[3] != ' ')) {
+      error = "unsupported Tor control reply framing";
+      return false;
+    }
+    reply.lines.push_back(line.substr(4));
+    if (line[3] == ' ') return true;
+  }
+}
+
+bool OnionService::sendCommand(std::string_view command, Reply& reply,
+                               std::string& error) {
+  if (!writeCommand(command, error) || !readReply(reply, error)) return false;
+  if (reply.status != 250) {
+    error = "Tor rejected " + std::string(command.substr(0, command.find(' '))) +
+        " with status " + std::to_string(reply.status);
+    if (!reply.lines.empty()) error += ": " + reply.lines.back();
+    return false;
+  }
+  return true;
+}
+
+bool OnionService::authenticate(std::string& error) {
+  Reply protocolInfo;
+  if (!sendCommand("PROTOCOLINFO 1", protocolInfo, error)) return false;
+  std::string authLine;
+  for (const auto& line : protocolInfo.lines) {
+    if (line.compare(0, 5, "AUTH ") == 0) {
+      authLine = line;
+      break;
+    }
+  }
+  const auto methodsStart = authLine.find("METHODS=");
+  if (methodsStart == std::string::npos) {
+    error = "Tor PROTOCOLINFO omitted authentication methods";
+    return false;
+  }
+  const auto methodsValueStart = methodsStart + 8;
+  const auto methodsEnd = authLine.find(' ', methodsValueStart);
+  const auto methods = std::string_view(authLine).substr(methodsValueStart,
+      methodsEnd == std::string::npos ? authLine.size() - methodsValueStart :
+                                       methodsEnd - methodsValueStart);
+
+  Reply authentication;
+  if (containsMethod(methods, "SAFECOOKIE")) {
+    const auto cookiePath = quotedValue(authLine, "COOKIEFILE=");
+    if (!cookiePath) {
+      error = "Tor SAFECOOKIE did not provide a valid cookie path";
+      return false;
+    }
+    const auto cookie = readCookie(*cookiePath);
+    if (!cookie) {
+      error = "Tor SAFECOOKIE file is unreadable or not 32 bytes";
+      return false;
+    }
+    std::array<unsigned char, NONCE_BYTES> clientNonce{};
+    if (RAND_bytes(clientNonce.data(), static_cast<int>(clientNonce.size())) != 1) {
+      error = "failed to generate Tor SAFECOOKIE nonce";
+      return false;
+    }
+    Reply challenge;
+    if (!sendCommand("AUTHCHALLENGE SAFECOOKIE " +
+        hexEncode(clientNonce.data(), clientNonce.size()), challenge, error)) {
+      return false;
+    }
+    if (challenge.lines.empty()) {
+      error = "Tor SAFECOOKIE challenge reply is empty";
+      return false;
+    }
+    const auto serverHash = hexDecode(fieldValue(challenge.lines.front(),
+                                                  "SERVERHASH="));
+    const auto serverNonce = hexDecode(fieldValue(challenge.lines.front(),
+                                                   "SERVERNONCE="));
+    if (!serverHash || serverHash->size() != 32 || !serverNonce ||
+        serverNonce->size() != NONCE_BYTES) {
+      error = "Tor SAFECOOKIE challenge reply is malformed";
+      return false;
+    }
+    std::vector<unsigned char> message;
+    message.reserve(cookie->size() + clientNonce.size() + serverNonce->size());
+    message.insert(message.end(), cookie->begin(), cookie->end());
+    message.insert(message.end(), clientNonce.begin(), clientNonce.end());
+    message.insert(message.end(), serverNonce->begin(), serverNonce->end());
+    unsigned int hashSize = 0;
+    const auto expectedServerHash = hmacSha256(SERVER_HASH_KEY, message, hashSize);
+    if (hashSize != serverHash->size() ||
+        CRYPTO_memcmp(expectedServerHash.data(), serverHash->data(), hashSize) != 0) {
+      error = "Tor SAFECOOKIE server authentication failed";
+      return false;
+    }
+    const auto clientHash = hmacSha256(CLIENT_HASH_KEY, message, hashSize);
+    if (!sendCommand("AUTHENTICATE " +
+        hexEncode(clientHash.data(), hashSize), authentication, error)) return false;
+    return true;
+  }
+  if (containsMethod(methods, "NULL") &&
+      m_controlEndpoint.compare(0, 5, "unix:") == 0) {
+    return sendCommand("AUTHENTICATE", authentication, error);
+  }
+  error = "Tor control endpoint offers neither SAFECOOKIE nor "
+          "permission-protected Unix NULL authentication";
+  return false;
+}
+
+bool OnionService::add(const Options& options, std::string& error) {
+  std::string privateKey;
+  const auto keyResult = loadPrivateKey(options.keyPath, privateKey);
+  if (keyResult == KeyLoadResult::INVALID) {
+    error = "Tor onion key is invalid or unreadable: " + options.keyPath;
+    return false;
+  }
+  const bool generating = keyResult == KeyLoadResult::MISSING;
+  const std::string key = generating ? "NEW:ED25519-V3" : privateKey;
+  Reply added;
+  const std::string command = "ADD_ONION " + key + " Port=" +
+      std::to_string(options.virtualPort) + "," + options.targetHost + ":" +
+      std::to_string(options.targetPort);
+  if (!sendCommand(command, added, error)) return false;
+  const auto serviceId = replyValue(added, "ServiceID=");
+  if (!validServiceId(serviceId)) {
+    error = "Tor returned an invalid v3 onion service ID";
+    return false;
+  }
+  if (generating) {
+    const auto returnedKey = replyValue(added, "PrivateKey=");
+    if (!validPrivateKey(returnedKey)) {
+      error = "Tor did not return a valid persistent ED25519-V3 key";
+      return false;
+    }
+    if (!savePrivateKey(options.keyPath, returnedKey)) {
+      Reply ignored;
+      std::string ignoredError;
+      static_cast<void>(sendCommand("DEL_ONION " + serviceId, ignored,
+                                    ignoredError));
+      error = "failed to persist Tor onion key at " + options.keyPath;
+      return false;
+    }
+  }
+  m_serviceId = serviceId;
+  m_hostname = serviceId + ".onion";
+  return true;
+}
+
+bool OnionService::start(const Options& options, std::string& error) {
+  stop();
+  error.clear();
+  if (!connectControl(options, error) || !authenticate(error) ||
+      !add(options, error)) {
+    closeConnection();
+    return false;
+  }
+  return true;
+}
+
+void OnionService::closeConnection() noexcept {
+  if (m_descriptor >= 0) ::close(m_descriptor);
+  m_descriptor = -1;
+  m_readBuffer.clear();
+  m_controlEndpoint.clear();
+}
+
+void OnionService::stop() noexcept {
+  if (m_descriptor >= 0 && !m_serviceId.empty()) {
+    Reply ignored;
+    std::string ignoredError;
+    static_cast<void>(sendCommand("DEL_ONION " + m_serviceId, ignored,
+                                  ignoredError));
+    static_cast<void>(writeCommand("QUIT", ignoredError));
+  }
+  closeConnection();
+  m_serviceId.clear();
+  m_hostname.clear();
+}
+
+} // namespace conspire::tor

--- a/server/src/utils/TorControl.hpp
+++ b/server/src/utils/TorControl.hpp
@@ -1,0 +1,64 @@
+#ifndef CONSPIRE_UTILS_TOR_CONTROL_HPP
+#define CONSPIRE_UTILS_TOR_CONTROL_HPP
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace conspire::tor {
+
+struct Options {
+  std::string controlSocket = "/run/tor/control";
+  std::string controlHost = "127.0.0.1";
+  std::uint16_t controlPort = 9051;
+  std::string keyPath = "conspire-onion.key";
+  std::string targetHost = "127.0.0.1";
+  std::uint16_t targetPort = 8080;
+  std::uint16_t virtualPort = 80;
+  std::chrono::milliseconds timeout{2000};
+};
+
+struct Reply {
+  int status = 0;
+  std::vector<std::string> lines;
+};
+
+bool validServiceId(std::string_view serviceId);
+bool validPrivateKey(std::string_view privateKey);
+std::string replyValue(const Reply& reply, std::string_view prefix);
+
+class OnionService {
+private:
+  int m_descriptor = -1;
+  std::string m_serviceId;
+  std::string m_hostname;
+  std::string m_controlEndpoint;
+  std::string m_readBuffer;
+
+  bool connectControl(const Options& options, std::string& error);
+  bool authenticate(std::string& error);
+  bool add(const Options& options, std::string& error);
+  bool sendCommand(std::string_view command, Reply& reply, std::string& error);
+  bool writeCommand(std::string_view command, std::string& error);
+  bool readReply(Reply& reply, std::string& error);
+  bool readLine(std::string& line, std::string& error);
+  void closeConnection() noexcept;
+
+public:
+  OnionService() = default;
+  OnionService(const OnionService&) = delete;
+  OnionService& operator=(const OnionService&) = delete;
+  ~OnionService();
+
+  bool start(const Options& options, std::string& error);
+  void stop() noexcept;
+  bool active() const { return m_descriptor >= 0 && !m_serviceId.empty(); }
+  const std::string& hostname() const { return m_hostname; }
+  const std::string& controlEndpoint() const { return m_controlEndpoint; }
+};
+
+} // namespace conspire::tor
+
+#endif

--- a/server/test/core_tests.cpp
+++ b/server/test/core_tests.cpp
@@ -43,6 +43,10 @@ int main() {
   assert(conspire::config::validStateFilePath("relative stats.json"));
   assert(!conspire::config::validStateFilePath(""));
   assert(!conspire::config::validStateFilePath("stats\n.json"));
+  assert(conspire::config::validLoopbackHost("127.0.0.1"));
+  assert(conspire::config::validLoopbackHost("::1"));
+  assert(conspire::config::validLoopbackHost("localhost"));
+  assert(!conspire::config::validLoopbackHost("control.example"));
   assert(conspire::boundaries::validRequestPath("/room/one"));
   assert(!conspire::boundaries::validRequestPath("//evil.test"));
   assert(!conspire::boundaries::validRequestPath("/room\r\none"));

--- a/server/test/tests.cpp
+++ b/server/test/tests.cpp
@@ -2,6 +2,7 @@
 #include "WSTest.hpp"
 #include "utils/AppConfig.hpp"
 #include "utils/Statistics.hpp"
+#include "utils/TorControl.hpp"
 
 #include "oatpp-test/UnitTest.hpp"
 #include <cassert>
@@ -19,6 +20,12 @@ void runConfigTests() {
   unsetenv("TLS_FILE_CERT_CHAIN");
   unsetenv("URL_STATS_PATH");
   unsetenv("STATS_STATE_PATH");
+  unsetenv("TOR_CONTROL_SOCKET");
+  unsetenv("TOR_CONTROL_HOST");
+  unsetenv("TOR_CONTROL_PORT");
+  unsetenv("TOR_BACKEND_PORT");
+  unsetenv("TOR_VIRTUAL_PORT");
+  unsetenv("TOR_KEY_PATH");
 
   setenv("TLS_FILE_PRIVATE_KEY", "/missing/key.pem", 1);
   setenv("TLS_FILE_CERT_CHAIN", "/missing/chain.pem", 1);
@@ -33,6 +40,25 @@ void runConfigTests() {
   assert(*plainConfig->getCanonicalBaseUrl() == "http://localhost:8080");
   assert(*plainConfig->getWebsocketBaseUrl() == "ws://localhost:8080");
   assert(!plainConfig->statisticsStatePath);
+  assert(plainConfig->torEnabled);
+  assert(plainConfig->torControlSocket &&
+         *plainConfig->torControlSocket == "/run/tor/control");
+  assert(plainConfig->torControlHost && *plainConfig->torControlHost == "127.0.0.1");
+  assert(plainConfig->torControlPort && *plainConfig->torControlPort == 9051);
+  assert(plainConfig->torBackendPort && *plainConfig->torBackendPort == 8080);
+  assert(plainConfig->torVirtualPort && *plainConfig->torVirtualPort == 80);
+  assert(plainConfig->torKeyPath && *plainConfig->torKeyPath == "conspire-onion.key");
+
+  plainConfig->onionHost = std::string(56, 'a') + ".onion";
+  const auto onionHost = std::string(56, 'a') + ".onion";
+  assert(plainConfig->isAllowedRequestHost("localhost:8080"));
+  assert(plainConfig->isAllowedRequestHost(onionHost));
+  assert(!plainConfig->isAllowedRequestHost("attacker.test"));
+  assert(*plainConfig->getOnionBaseUrl() == "http://" + onionHost);
+  assert(*plainConfig->getWebsocketBaseUrlForHost(onionHost) ==
+         "ws://" + onionHost + ":80");
+  assert(plainConfig->isAllowedOrigin("http://" + onionHost, false));
+  assert(!plainConfig->isAllowedOrigin("http://attacker.test", false));
 
   const char* persistentArguments[] = {
       "conspire", "--stats-state", "/var/lib/conspire/stats.json"};
@@ -40,6 +66,8 @@ void runConfigTests() {
       oatpp::base::CommandLineArguments(3, persistentArguments));
   assert(persistentConfig->statisticsStatePath &&
          *persistentConfig->statisticsStatePath == "/var/lib/conspire/stats.json");
+  assert(persistentConfig->torKeyPath &&
+         *persistentConfig->torKeyPath == "/var/lib/conspire/onion.key");
 
   const char* missingStatePathArguments[] = {"conspire", "--stats-state"};
   bool missingStatePathRejected = false;
@@ -64,6 +92,28 @@ void runConfigTests() {
   assert(tlsConfig->tlsCertificateChainPath && *tlsConfig->tlsCertificateChainPath == "test-chain.pem");
   assert(*tlsConfig->getCanonicalBaseUrl() == "https://localhost:8443");
   assert(*tlsConfig->getWebsocketBaseUrl() == "wss://localhost:8443");
+  assert(tlsConfig->torBackendPort && *tlsConfig->torBackendPort == 8080);
+
+  const char* torArguments[] = {
+      "conspire", "--no-tor", "--tor-control-host", "localhost",
+      "--tor-control-port", "19051", "--tor-backend-port", "18080",
+      "--tor-virtual-port", "8088", "--tor-key", "/tmp/conspire.key"};
+  const auto torConfig = conspire::config::fromCommandLine(
+      oatpp::base::CommandLineArguments(12, torArguments));
+  assert(!torConfig->torEnabled);
+  assert(*torConfig->torControlHost == "localhost");
+  assert(*torConfig->torControlPort == 19051);
+  assert(*torConfig->torBackendPort == 18080);
+  assert(*torConfig->torVirtualPort == 8088);
+  assert(*torConfig->torKeyPath == "/tmp/conspire.key");
+
+  assert(conspire::tor::validServiceId(std::string(56, 'a')));
+  assert(!conspire::tor::validServiceId(std::string(55, 'a')));
+  assert(!conspire::tor::validServiceId(std::string(56, '1')));
+  assert(conspire::tor::validPrivateKey(
+      "ED25519-V3:" + std::string(86, 'A') + "=="));
+  assert(!conspire::tor::validPrivateKey("ED25519-V3:QUFBQQ=="));
+  assert(!conspire::tor::validPrivateKey("RSA1024:QUFBQQ=="));
 }
 
 void runStatisticsPersistenceTests() {

--- a/test/e2e/chat-session.test.mjs
+++ b/test/e2e/chat-session.test.mjs
@@ -1,16 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { createServer } from 'node:net';
+import { request as httpRequest } from 'node:http';
+import { createHmac, randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
 import WebSocket from 'ws';
 
 const root = fileURLToPath(new URL('../..', import.meta.url));
 const binary = resolve(root, process.env.CONSPIRE_E2E_BINARY ?? 'build/native-gcc/server/conspire-exe');
 const messageCode = Object.freeze({ info: 0, peerJoined: 1, peerMessage: 3 });
+const execFileAsync = promisify(execFile);
 
 function delay(milliseconds) {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
@@ -71,11 +75,15 @@ function startConspire(port, extraArguments = []) {
   const environment = { ...process.env };
   for (const name of [
     'EXTERNAL_ADDRESS', 'EXTERNAL_PORT', 'TLS_FILE_PRIVATE_KEY',
-    'TLS_FILE_CERT_CHAIN', 'URL_STATS_PATH',
+    'TLS_FILE_CERT_CHAIN', 'URL_STATS_PATH', 'STATS_STATE_PATH',
+    'TOR_CONTROL_SOCKET', 'TOR_CONTROL_HOST', 'TOR_CONTROL_PORT',
+    'TOR_BACKEND_PORT', 'TOR_VIRTUAL_PORT', 'TOR_KEY_PATH',
   ]) delete environment[name];
 
+  const torConfigured = extraArguments.includes('--tor-control-port');
   const child = spawn(binary, [
-    '--host', 'localhost', '--port', String(port), ...extraArguments,
+    '--host', 'localhost', '--port', String(port),
+    ...(torConfigured ? [] : ['--no-tor']), ...extraArguments,
   ], {
     cwd: tmpdir(),
     env: environment,
@@ -106,8 +114,8 @@ async function waitForServer(server, origin) {
   }, 10_000);
 }
 
-async function connectClient(url, origin) {
-  const socket = new WebSocket(url, { origin });
+async function connectClient(url, origin, headers = undefined) {
+  const socket = new WebSocket(url, { origin, headers });
   const messages = [];
   const socketErrors = [];
   socket.on('message', (payload) => {
@@ -147,6 +155,91 @@ async function connectClient(url, origin) {
     socket.once('unexpected-response', onUnexpectedResponse);
   });
   return { socket, messages, socketErrors };
+}
+
+async function requestText(port, path, headers = {}) {
+  return new Promise((resolveRequest, rejectRequest) => {
+    const request = httpRequest({
+      host: '127.0.0.1', port, path, headers,
+    }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => resolveRequest({
+        status: response.statusCode,
+        headers: response.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    request.once('error', rejectRequest);
+    request.end();
+  });
+}
+
+async function startFakeTor(cookiePath) {
+  const serviceId = 'a'.repeat(56);
+  const privateKey = `ED25519-V3:${'A'.repeat(86)}==`;
+  const cookie = randomBytes(32);
+  await writeFile(cookiePath, cookie, { mode: 0o600 });
+  const commands = [];
+  const connections = new Set();
+  const server = createServer((socket) => {
+    connections.add(socket);
+    socket.once('close', () => connections.delete(socket));
+    let buffered = '';
+    socket.on('data', (chunk) => {
+      buffered += chunk.toString('utf8');
+      while (buffered.includes('\r\n')) {
+        const lineEnd = buffered.indexOf('\r\n');
+        const command = buffered.slice(0, lineEnd);
+        buffered = buffered.slice(lineEnd + 2);
+        commands.push(command);
+        if (command === 'PROTOCOLINFO 1') {
+          socket.write(`250-PROTOCOLINFO 1\r\n250-AUTH METHODS=SAFECOOKIE COOKIEFILE="${cookiePath}"\r\n250-VERSION Tor="test"\r\n250 OK\r\n`);
+        } else if (command.startsWith('AUTHCHALLENGE SAFECOOKIE ')) {
+          const clientNonce = Buffer.from(command.slice('AUTHCHALLENGE SAFECOOKIE '.length), 'hex');
+          const serverNonce = randomBytes(32);
+          const message = Buffer.concat([cookie, clientNonce, serverNonce]);
+          const serverHash = createHmac('sha256',
+            'Tor safe cookie authentication server-to-controller hash')
+            .update(message).digest('hex').toUpperCase();
+          socket.expectedClientHash = createHmac('sha256',
+            'Tor safe cookie authentication controller-to-server hash')
+            .update(message).digest('hex').toUpperCase();
+          socket.write(`250 AUTHCHALLENGE SERVERHASH=${serverHash} SERVERNONCE=${serverNonce.toString('hex').toUpperCase()}\r\n`);
+        } else if (command === `AUTHENTICATE ${socket.expectedClientHash}`) {
+          socket.write('250 OK\r\n');
+        } else if (command.startsWith('ADD_ONION NEW:ED25519-V3 ')) {
+          socket.write(`250-ServiceID=${serviceId}\r\n250-PrivateKey=${privateKey}\r\n250 OK\r\n`);
+        } else if (command.startsWith(`ADD_ONION ${privateKey} `)) {
+          socket.write(`250-ServiceID=${serviceId}\r\n250 OK\r\n`);
+        } else if (command === `DEL_ONION ${serviceId}`) {
+          socket.write('250 OK\r\n');
+        } else if (command === 'QUIT') {
+          socket.end();
+        } else {
+          socket.write('510 Unrecognized command\r\n');
+        }
+      }
+    });
+  });
+  await new Promise((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  return {
+    port: address.port,
+    serviceId,
+    privateKey,
+    commands,
+    close: async () => {
+      for (const connection of connections) connection.destroy();
+      await new Promise((resolveClose, rejectClose) => server.close(
+        (error) => error ? rejectClose(error) : resolveClose(),
+      ));
+    },
+  };
 }
 
 async function waitForMessage(client, description, predicate) {
@@ -225,6 +318,165 @@ test('real server serves its embedded dashboard and configured statistics path',
         { cause: scenarioError });
     }
     assert.deepEqual(exit, { code: 0, signal: null }, `Conspire output:\n${diagnostics}`);
+  });
+
+test('Tor ADD_ONION identity persists and onion Host/Origin drive the frontend',
+  { timeout: 30_000 }, async () => {
+    const stateDirectory = await mkdtemp(join(tmpdir(), 'conspire-tor-e2e-'));
+    const keyPath = join(stateDirectory, 'onion.key');
+    const cookiePath = join(stateDirectory, 'control.authcookie');
+    const controlSocket = join(stateDirectory, 'missing-control.sock');
+    const fakeTor = await startFakeTor(cookiePath);
+    const onionHost = `${fakeTor.serviceId}.onion`;
+    const onionOrigin = `http://${onionHost}`;
+    let activeServer;
+    let scenarioError;
+
+    const torArguments = [
+      '--tor-control-socket', controlSocket,
+      '--tor-control-host', '127.0.0.1',
+      '--tor-control-port', String(fakeTor.port),
+      '--tor-key', keyPath,
+    ];
+
+    try {
+      const firstPort = await reservePort();
+      activeServer = startConspire(firstPort, torArguments);
+      await waitForServer(activeServer, `http://localhost:${firstPort}`);
+      await waitUntil('first ADD_ONION command', () =>
+        fakeTor.commands.find((command) => command.startsWith('ADD_ONION ')));
+
+      const homepage = await requestText(firstPort, '/', { Host: onionHost });
+      assert.equal(homepage.status, 200);
+      assert.match(homepage.body, />Tor hidden service<\/a>/);
+      assert.match(homepage.body, new RegExp(`href="${onionOrigin}"`));
+
+      const chatScript = await requestText(firstPort, '/room/tor-room/chat.js', {
+        Host: onionHost,
+      });
+      assert.equal(chatScript.status, 200);
+      assert.match(chatScript.body,
+        new RegExp(`urlWebsocket: "ws://${onionHost}:80/api/ws/room/tor-room"`));
+
+      const onionClient = await connectClient(
+        `ws://127.0.0.1:${firstPort}/api/ws/room/tor-room/`, onionOrigin,
+        { Host: onionHost },
+      );
+      await waitForMessage(onionClient, 'onion-origin peer onboarding',
+        (message) => message.code === messageCode.info);
+      await closeClient(onionClient);
+
+      assert.deepEqual(await stopConspire(activeServer), { code: 0, signal: null });
+      activeServer = undefined;
+      assert(fakeTor.commands.includes(`DEL_ONION ${fakeTor.serviceId}`));
+      assert.equal((await readFile(keyPath, 'utf8')).trim(), fakeTor.privateKey);
+      assert.equal((await stat(keyPath)).mode & 0o077, 0);
+      assert(fakeTor.commands.includes(
+        `ADD_ONION NEW:ED25519-V3 Port=80,127.0.0.1:${firstPort}`));
+
+      const secondPort = await reservePort();
+      activeServer = startConspire(secondPort, torArguments);
+      await waitForServer(activeServer, `http://localhost:${secondPort}`);
+      await waitUntil('persistent-key ADD_ONION command', () =>
+        fakeTor.commands.find((command) =>
+          command.startsWith(`ADD_ONION ${fakeTor.privateKey} `)));
+      assert(fakeTor.commands.includes(
+        `ADD_ONION ${fakeTor.privateKey} Port=80,127.0.0.1:${secondPort}`));
+      assert.deepEqual(await stopConspire(activeServer), { code: 0, signal: null });
+      activeServer = undefined;
+
+      const invalidKey = 'not-a-tor-key\n';
+      await writeFile(keyPath, invalidKey, { mode: 0o600 });
+      const thirdPort = await reservePort();
+      activeServer = startConspire(thirdPort, torArguments);
+      await waitForServer(activeServer, `http://localhost:${thirdPort}`);
+      assert.equal(fakeTor.commands.filter(
+        (command) => command.startsWith('ADD_ONION ')).length, 2);
+      assert.match(activeServer.getOutput(), /Tor onion key is invalid or unreadable/);
+      assert.deepEqual(await stopConspire(activeServer), { code: 0, signal: null });
+      activeServer = undefined;
+      assert.equal(await readFile(keyPath, 'utf8'), invalidKey);
+    } catch (error) {
+      scenarioError = error;
+    }
+
+    if (activeServer) {
+      try {
+        await stopConspire(activeServer);
+      } catch (error) {
+        scenarioError ??= error;
+      }
+    }
+    await fakeTor.close();
+    await rm(stateDirectory, { recursive: true, force: true });
+    if (scenarioError) throw scenarioError;
+  });
+
+test('TLS mode exposes a separate loopback HTTP backend for onion port 80',
+  { timeout: 30_000 }, async () => {
+    const stateDirectory = await mkdtemp(join(tmpdir(), 'conspire-tor-tls-e2e-'));
+    const certificatePath = join(stateDirectory, 'certificate.pem');
+    const privateKeyPath = join(stateDirectory, 'private-key.pem');
+    const cookiePath = join(stateDirectory, 'control.authcookie');
+    const onionKeyPath = join(stateDirectory, 'onion.key');
+    const controlSocket = join(stateDirectory, 'missing-control.sock');
+    let fakeTor;
+    let server;
+    let scenarioError;
+
+    try {
+      await execFileAsync('openssl', [
+        'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-days', '1',
+        '-subj', '/CN=localhost', '-keyout', privateKeyPath,
+        '-out', certificatePath,
+      ]);
+      fakeTor = await startFakeTor(cookiePath);
+      const tlsPort = await reservePort();
+      const backendPort = await reservePort();
+      const onionHost = `${fakeTor.serviceId}.onion`;
+      server = startConspire(tlsPort, [
+        '--tls', '--tls-key', privateKeyPath, '--tls-chain', certificatePath,
+        '--tor-control-socket', controlSocket,
+        '--tor-control-host', '127.0.0.1',
+        '--tor-control-port', String(fakeTor.port),
+        '--tor-key', onionKeyPath,
+        '--tor-backend-port', String(backendPort),
+      ]);
+
+      await waitUntil('Tor loopback HTTP backend', async () => {
+        if (server.getProcessError()) throw server.getProcessError();
+        if (server.child.exitCode !== null) {
+          throw new Error(`server exited with ${server.child.exitCode}`);
+        }
+        const response = await requestText(backendPort, '/', { Host: onionHost });
+        return response.status === 200;
+      }, 10_000);
+      assert(fakeTor.commands.includes(
+        `ADD_ONION NEW:ED25519-V3 Port=80,127.0.0.1:${backendPort}`));
+
+      const onionClient = await connectClient(
+        `ws://127.0.0.1:${backendPort}/api/ws/room/tls-tor-room/`,
+        `http://${onionHost}`, { Host: onionHost },
+      );
+      await waitForMessage(onionClient, 'TLS-mode onion peer onboarding',
+        (message) => message.code === messageCode.info);
+      await closeClient(onionClient);
+      assert.deepEqual(await stopConspire(server), { code: 0, signal: null });
+      server = undefined;
+    } catch (error) {
+      scenarioError = error;
+    }
+
+    if (server) {
+      try {
+        await stopConspire(server);
+      } catch (error) {
+        scenarioError ??= error;
+      }
+    }
+    if (fakeTor) await fakeTor.close();
+    await rm(stateDirectory, { recursive: true, force: true });
+    if (scenarioError) throw scenarioError;
   });
 
 test('statistics survive a graceful process restart', { timeout: 30_000 }, async () => {

--- a/test/playwright/chat-ui.spec.mjs
+++ b/test/playwright/chat-ui.spec.mjs
@@ -35,7 +35,7 @@ function startConspire(port) {
   ]) delete environment[name];
 
   const child = spawn(binary, [
-    '--host', 'localhost', '--port', String(port),
+    '--host', 'localhost', '--port', String(port), '--no-tor',
   ], {
     cwd: tmpdir(),
     env: environment,
@@ -129,6 +129,7 @@ test('users chat through the browser UI and a newcomer receives history', async 
     await expect(landing.locator('body')).toHaveCSS('background-color', 'rgb(255, 255, 255)');
     await expect(landing.getByRole('button', { name: 'Public Reception' })).toBeVisible();
     await expect(landing.getByRole('button', { name: 'New Private Room' })).toBeVisible();
+    await expect(landing.getByRole('link', { name: 'Tor hidden service' })).toHaveCount(0);
 
     const firstPageOpened = firstContext.waitForEvent('page');
     await landing.getByRole('button', { name: 'Public Reception' }).click();

--- a/test/static-quality.test.mjs
+++ b/test/static-quality.test.mjs
@@ -24,6 +24,17 @@ test('served pages expose the build-version title placeholder', async () => {
   assert.match(controller, /replaceLiteral\(page, "%%%CONSPIRE_TITLE%%%"/);
 });
 
+test('the landing page has a build-time-safe onion-service insertion point', async () => {
+  const [html, controller] = await Promise.all([
+    readFile(new URL('../front/index.html', import.meta.url), 'utf8'),
+    readFile(new URL('../server/src/controller/StaticController.hpp', import.meta.url), 'utf8'),
+  ]);
+  assert.match(html, /%%%TOR_HIDDEN_SERVICE_BUTTON%%%/);
+  assert.match(controller, /getOnionBaseUrl\(\)/);
+  assert.match(controller, />Tor hidden service<\/a>/);
+  assert.match(controller, /htmlText\(\*onionBaseUrl\)/);
+});
+
 test('the server embeds its complete frontend and dashboard instead of loading runtime files', async () => {
   const [cmake, generator, controller] = await Promise.all([
     readFile(new URL('../server/CMakeLists.txt', import.meta.url), 'utf8'),


### PR DESCRIPTION
## Summary

- discover Tor through a configurable Unix control socket with loopback TCP fallback
- authenticate with SAFECOOKIE and register an attached v3 service through `ADD_ONION`
- persist the ED25519-V3 identity at configurable `--tor-key` / `TOR_KEY_PATH` storage with mode 0600
- expose a loopback-only plaintext backend for onion port 80 when clearnet TLS is enabled
- accept the generated onion hostname and Origin for HTTP redirects and WebSocket sessions
- add a homepage **Tor hidden service** button and document native/systemd configuration

Tor integration is best-effort: clearnet startup continues if Tor is unavailable. Graceful shutdown removes the attached service with `DEL_ONION`, while the saved identity restores the same address on restart.

## Verification

- `ctest --preset native-gcc --output-on-failure` — 3/3 passed
- `npm run test:e2e` — 6/6 passed, including SAFECOOKIE, identity reuse, invalid-key preservation, onion WebSockets, and TLS dual listeners
- `npm run check:web` — 15/15 passed
- `CONSPIRE_E2E_VERSION=e2e npm run test:e2e:browser` — 1/1 passed
- `./scripts/run-static-analysis.sh` — passed
- release input, artifact-copy, and container contracts — passed
- x86_64 musl static release build — passed
