### PR TITLE
fix: restore file transfers across transports

### DIFF
--- a/front/chat/chat.js
+++ b/front/chat/chat.js
@@ -1,5 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 import { humanFileSize } from './format.js';
+import { createFileChunkMessage } from './protocol.js';
 import { createChatState } from './state.js';
 
 const { urlWebsocket, urlRoom } = globalThis.ConspireChatConfig;
@@ -14,7 +15,6 @@ let CODE_PEER_IS_TYPING = 5;
 
 let CODE_FILE_SHARE = 6;
 let CODE_FILE_REQUEST_CHUNK = 7;
-let CODE_FILE_CHUNK_DATA = 8;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -475,22 +475,10 @@ function sendFileChunks(message) {
             reader.onloadend = function () {
 
                 let data = btoa(reader.result);
-
-                let chunkData = {
-                    serverFileId: chunkInfo.serverFileId,
-                    subscriberId: chunkInfo.subscriberId,
-                    data: data
-                }
-
-                let message = {
-                    peerId: peerId,
-                    code: CODE_FILE_CHUNK_DATA,
-                    files: [chunkData]
-                }
-
-                socketSendNextData(JSON.stringify(message));
-
                 let chunkSize = posEnd - chunkInfo.chunkPosition;
+                socketSendNextData(JSON.stringify(
+                    createFileChunkMessage(chunkInfo, data, chunkSize)));
+
                 let sentLabel = document.getElementById("file_served_" + chunkInfo.serverFileId);
                 let sent = parseInt(sentLabel.getAttribute("amount-sent")) + chunkSize;
                 let spin = parseInt(sentLabel.getAttribute("progress-spin")) + 1;

--- a/front/chat/protocol.js
+++ b/front/chat/protocol.js
@@ -25,6 +25,19 @@ export function roomFileUrl(roomUrl, serverFileId) {
   return `${roomUrl.replace(/\/$/, '')}/file/${encodeURIComponent(String(serverFileId))}`;
 }
 
+export function createFileChunkMessage(request, data, chunkSize) {
+  return {
+    code: MessageCode.FILE_CHUNK_DATA,
+    files: [{
+      serverFileId: request.serverFileId,
+      subscriberId: request.subscriberId,
+      chunkPosition: request.chunkPosition,
+      chunkSize,
+      data,
+    }],
+  };
+}
+
 export function humanFileSize(bytes) {
   if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
   const units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB'];

--- a/test/browser-protocol.test.mjs
+++ b/test/browser-protocol.test.mjs
@@ -1,6 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { MessageCode, humanFileSize, parseProtocolMessage, roomFileUrl } from '../front/chat/protocol.js';
+import {
+  MessageCode,
+  createFileChunkMessage,
+  humanFileSize,
+  parseProtocolMessage,
+  roomFileUrl,
+} from '../front/chat/protocol.js';
 import { createChatState } from '../front/chat/state.js';
 import { humanFileSize as formatFileSize } from '../front/chat/format.js';
 import { readFile } from 'node:fs/promises';
@@ -26,6 +32,25 @@ test('file URLs and file sizes are deterministic at boundaries', () => {
   assert.equal(humanFileSize(-1), '0 B');
 });
 
+test('file chunk replies preserve the requested transfer coordinates', () => {
+  const request = {
+    serverFileId: 12,
+    subscriberId: 34,
+    chunkPosition: 4096,
+    chunkSize: 4096,
+  };
+  assert.deepEqual(createFileChunkMessage(request, 'YWJj', 3), {
+    code: MessageCode.FILE_CHUNK_DATA,
+    files: [{
+      serverFileId: 12,
+      subscriberId: 34,
+      chunkPosition: 4096,
+      chunkSize: 3,
+      data: 'YWJj',
+    }],
+  });
+});
+
 test('chat state and formatting modules are isolated from the DOM', () => {
   const first = createChatState();
   const second = createChatState();
@@ -41,6 +66,7 @@ test('the shipped chat receive path imports and validates the protocol module', 
   const chat = await readFile(new URL('../front/chat/chat.js', import.meta.url), 'utf8');
   assert.match(chat, /import\(urlRoom \+ "\/protocol\.js"\)/);
   assert.match(chat, /protocol\.parseProtocolMessage\(event\.data\)/);
+  assert.match(chat, /createFileChunkMessage\(chunkInfo, data, chunkSize\)/);
   assert.doesNotMatch(chat, /onMessage\(JSON\.parse\(event\.data\)\)/);
 });
 
@@ -51,6 +77,7 @@ test('room module imports have explicit matching server routes', async () => {
     readFile(new URL('../server/src/controller/StaticController.hpp', import.meta.url), 'utf8'),
   ]);
   assert.match(chat, /from '\.\/format\.js'/);
+  assert.match(chat, /from '\.\/protocol\.js'/);
   assert.match(chat, /from '\.\/state\.js'/);
   assert.match(ui, /from '\.\/chat\.js'/);
   for (const route of ['format.js', 'state.js', 'chat.js', 'ui.js', 'protocol.js']) {

--- a/test/e2e/chat-session.test.mjs
+++ b/test/e2e/chat-session.test.mjs
@@ -10,10 +10,18 @@ import { fileURLToPath } from 'node:url';
 import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import WebSocket from 'ws';
+import { createFileChunkMessage } from '../../front/chat/protocol.js';
 
 const root = fileURLToPath(new URL('../..', import.meta.url));
 const binary = resolve(root, process.env.CONSPIRE_E2E_BINARY ?? 'build/native-gcc/server/conspire-exe');
-const messageCode = Object.freeze({ info: 0, peerJoined: 1, peerMessage: 3 });
+const messageCode = Object.freeze({
+  info: 0,
+  peerJoined: 1,
+  peerMessage: 3,
+  peerFile: 4,
+  fileShare: 6,
+  fileRequestChunk: 7,
+});
 const execFileAsync = promisify(execFile);
 
 function delay(milliseconds) {
@@ -168,6 +176,24 @@ async function requestText(port, path, headers = {}) {
         status: response.statusCode,
         headers: response.headers,
         body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    request.once('error', rejectRequest);
+    request.end();
+  });
+}
+
+async function requestBuffer(port, path, headers = {}) {
+  return new Promise((resolveRequest, rejectRequest) => {
+    const request = httpRequest({
+      host: '127.0.0.1', port, path, headers,
+    }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => resolveRequest({
+        status: response.statusCode,
+        headers: response.headers,
+        body: Buffer.concat(chunks),
       }));
     });
     request.once('error', rejectRequest);
@@ -612,3 +638,178 @@ test('real server broadcasts chat messages and supplies room history', { timeout
   }
   assert.deepEqual(exit, { code: 0, signal: null }, `Conspire output:\n${diagnostics}`);
 });
+
+test('real server transfers file contents without disconnecting either peer',
+  { timeout: 30_000 }, async () => {
+    const port = await reservePort();
+    const origin = `http://localhost:${port}`;
+    const room = 'e2e-file-room';
+    const websocketUrl = `ws://localhost:${port}/api/ws/room/${room}/`;
+    const server = startConspire(port);
+    const clients = [];
+    const contents = Buffer.alloc(64 * 1024);
+    for (let index = 0; index < contents.length; index += 1) contents[index] = index % 251;
+    let scenarioError;
+
+    try {
+      await waitForServer(server, origin);
+      const offerer = await connectClient(websocketUrl, origin);
+      clients.push(offerer);
+      await waitForMessage(offerer, 'file offerer onboarding',
+        (message) => message.code === messageCode.info);
+
+      const downloader = await connectClient(websocketUrl, origin);
+      clients.push(downloader);
+      await waitForMessage(downloader, 'file downloader onboarding',
+        (message) => message.code === messageCode.info);
+
+      let responseError;
+      offerer.socket.on('message', (payload) => {
+        try {
+          const message = JSON.parse(payload.toString());
+          if (message.code !== messageCode.fileRequestChunk) return;
+          const request = message.files[0];
+          const chunk = contents.subarray(
+            request.chunkPosition, request.chunkPosition + request.chunkSize);
+          offerer.socket.send(JSON.stringify(createFileChunkMessage(
+            request, chunk.toString('base64'), chunk.length)));
+        } catch (error) {
+          responseError = error;
+        }
+      });
+
+      await sendJson(offerer, {
+        code: messageCode.fileShare,
+        files: [{ clientFileId: 1, name: 'transfer.bin', size: contents.length }],
+      });
+      const shared = await waitForMessage(downloader, 'shared file announcement',
+        (message) => message.code === messageCode.peerFile);
+      const response = await fetch(
+        `${origin}/room/${room}/file/${shared.files[0].serverFileId}`);
+      assert.equal(response.status, 200);
+      assert.deepEqual(Buffer.from(await response.arrayBuffer()), contents);
+      assert.ifError(responseError);
+      assert.equal(offerer.socket.readyState, WebSocket.OPEN);
+      assert.equal(downloader.socket.readyState, WebSocket.OPEN);
+      assert.equal(offerer.messages.filter(
+        (message) => message.code === messageCode.fileRequestChunk).length, 16);
+    } catch (error) {
+      scenarioError = error;
+    }
+
+    for (const client of clients.reverse()) {
+      try {
+        await closeClient(client);
+      } catch (error) {
+        scenarioError ??= error;
+      }
+    }
+
+    let exit;
+    try {
+      exit = await stopConspire(server);
+    } catch (error) {
+      scenarioError ??= error;
+    }
+
+    const diagnostics = server.getOutput();
+    if (scenarioError) {
+      throw new Error(`${scenarioError.message}\nConspire output:\n${diagnostics}`,
+        { cause: scenarioError });
+    }
+    assert.deepEqual(exit, { code: 0, signal: null }, `Conspire output:\n${diagnostics}`);
+  });
+
+test('real server transfers from a clearnet offerer to an onion downloader',
+  { timeout: 30_000 }, async () => {
+    const stateDirectory = await mkdtemp(join(tmpdir(), 'conspire-file-tor-e2e-'));
+    const keyPath = join(stateDirectory, 'onion.key');
+    const cookiePath = join(stateDirectory, 'control.authcookie');
+    const controlSocket = join(stateDirectory, 'missing-control.sock');
+    const fakeTor = await startFakeTor(cookiePath);
+    const onionHost = `${fakeTor.serviceId}.onion`;
+    const onionOrigin = `http://${onionHost}`;
+    const port = await reservePort();
+    const clearnetOrigin = `http://localhost:${port}`;
+    const room = 'e2e-mixed-file-room';
+    const websocketPath = `/api/ws/room/${room}/`;
+    const server = startConspire(port, [
+      '--tor-control-socket', controlSocket,
+      '--tor-control-host', '127.0.0.1',
+      '--tor-control-port', String(fakeTor.port),
+      '--tor-key', keyPath,
+    ]);
+    const clients = [];
+    const contents = Buffer.from('conspire mixed clearnet and onion transfer');
+    let scenarioError;
+
+    try {
+      await waitForServer(server, clearnetOrigin);
+      await waitUntil('file-transfer ADD_ONION command', () =>
+        fakeTor.commands.find((command) => command.startsWith('ADD_ONION ')));
+
+      const offerer = await connectClient(
+        `ws://localhost:${port}${websocketPath}`, clearnetOrigin);
+      clients.push(offerer);
+      await waitForMessage(offerer, 'mixed file offerer onboarding',
+        (message) => message.code === messageCode.info);
+
+      const downloader = await connectClient(
+        `ws://127.0.0.1:${port}${websocketPath}`, onionOrigin, { Host: onionHost });
+      clients.push(downloader);
+      await waitForMessage(downloader, 'mixed file downloader onboarding',
+        (message) => message.code === messageCode.info);
+
+      let responseError;
+      offerer.socket.on('message', (payload) => {
+        try {
+          const message = JSON.parse(payload.toString());
+          if (message.code !== messageCode.fileRequestChunk) return;
+          const request = message.files[0];
+          const chunk = contents.subarray(
+            request.chunkPosition, request.chunkPosition + request.chunkSize);
+          offerer.socket.send(JSON.stringify(createFileChunkMessage(
+            request, chunk.toString('base64'), chunk.length)));
+        } catch (error) {
+          responseError = error;
+        }
+      });
+
+      await sendJson(offerer, {
+        code: messageCode.fileShare,
+        files: [{ clientFileId: 1, name: 'mixed.txt', size: contents.length }],
+      });
+      const shared = await waitForMessage(downloader, 'mixed shared file announcement',
+        (message) => message.code === messageCode.peerFile);
+      const response = await requestBuffer(port,
+        `/room/${room}/file/${shared.files[0].serverFileId}`, { Host: onionHost });
+      assert.equal(response.status, 200);
+      assert.deepEqual(response.body, contents);
+      assert.ifError(responseError);
+      assert.equal(offerer.socket.readyState, WebSocket.OPEN);
+      assert.equal(downloader.socket.readyState, WebSocket.OPEN);
+    } catch (error) {
+      scenarioError = error;
+    }
+
+    for (const client of clients.reverse()) {
+      try {
+        await closeClient(client);
+      } catch (error) {
+        scenarioError ??= error;
+      }
+    }
+    try {
+      const exit = await stopConspire(server);
+      assert.deepEqual(exit, { code: 0, signal: null });
+    } catch (error) {
+      scenarioError ??= error;
+    }
+    await fakeTor.close();
+    await rm(stateDirectory, { recursive: true, force: true });
+
+    if (scenarioError) {
+      throw new Error(`${scenarioError.message}\nConspire output:\n${server.getOutput()}`,
+        { cause: scenarioError });
+    }
+  });


### PR DESCRIPTION
## Summary

- preserve chunk position and actual size in browser file-transfer replies
- share the response constructor between the shipped frontend and protocol tests
- add real-server clearnet-to-clearnet and clearnet-to-onion transfer coverage without Playwright

## Root cause

The hardened server validates chunkPosition and chunkSize, but the browser omitted both fields. The server rejected the first chunk as invalid, closed the offering peer WebSocket, and terminated the download.

## Verification

- npm run check:web — 16 passed
- npm run test:e2e — 8 passed
- npm run coverage:browser — 95.89% lines, 94.12% branches
- cmake --preset core-coverage-gcc && cmake --build --preset core-coverage-gcc && ctest --preset core-coverage-gcc — 4 passed
- cmake --build --preset native-gcc --target conspire-exe -j2 — passed with ccache enabled
- ./scripts/run-static-analysis.sh — shellcheck and cppcheck passed

No Playwright or browser emulation is used by the new transfer tests.